### PR TITLE
Fix `prepare` when using as git repository dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "!/contracts/mocks/**/*"
   ],
   "scripts": {
-    "prepare": "git config --local core.hooksPath .githooks",
+    "prepare": "scripts/prepare.sh",
     "compile": "hardhat compile",
     "lint": "prettier --log-level warn --ignore-path .gitignore '{contracts,test}/**/*.sol' --check",
     "lint:fix": "prettier --log-level warn --ignore-path .gitignore '{contracts,test}/**/*.sol' --write",

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if git status &>/dev/null; then git config core.hooksPath .githooks; fi


### PR DESCRIPTION
Implements https://github.com/OpenZeppelin/openzeppelin-contracts/commit/4764ea50750d8bda9096e833706beba86918b163