### PR TITLE
Simplify remappings and use master for OpenZeppelin dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,4 +20,5 @@ runs:
       with:
         version: nightly
     - name: Install submodule dependencies
+      shell: bash
       run: forge install

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,3 +19,4 @@ runs:
       uses: foundry-rs/foundry-toolchain@v1
       with:
         version: nightly
+    - run: forge install

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,4 +19,5 @@ runs:
       uses: foundry-rs/foundry-toolchain@v1
       with:
         version: nightly
-    - run: forge install
+    - name: Install submodule dependencies
+      run: forge install

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,8 +35,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
-      - name: Bring vanilla repository test utils as a submodule
-        run: forge install
       - name: Run tests and generate gas report
         run: npm run test
 
@@ -46,8 +44,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
-      - name: Bring vanilla repository test utils as a submodule
-        run: forge install
       - name: Run coverage
         run: npm run coverage
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,7 +64,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
-      - run: rm foundry.toml
       - uses: crytic/slither-action@v0.4.0
 
   codespell:

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = '0.8.26'
+solc_version = '0.8.27'
 evm_version = 'cancun'
 src = 'contracts'
 out = 'out'

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,7 +3,7 @@ const { argv } = require('yargs/yargs')()
   .options({
     compiler: {
       type: 'string',
-      default: '0.8.26',
+      default: '0.8.27',
     },
     hardfork: {
       type: 'string',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "@openzeppelin/community-contracts",
       "version": "0.0.1",
       "license": "MIT",
-      "dependencies": {
-        "@openzeppelin/contracts": "^5.0.2",
-        "@openzeppelin/contracts-upgradeable": "^5.0.2"
-      },
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
         "@nomicfoundation/hardhat-ethers": "^3.0.5",
@@ -1125,19 +1121,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@openzeppelin/contracts": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.2.tgz",
-      "integrity": "sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA=="
-    },
-    "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.2.tgz",
-      "integrity": "sha512-0MmkHSHiW2NRFiT9/r5Lu4eJq5UJ4/tzlOgYXNAIj/ONkQTVnz22pLxDvp4C4uZ9he7ZFvGn3Driptn1/iU7tQ==",
-      "peerDependencies": {
-        "@openzeppelin/contracts": "5.0.2"
       }
     },
     "node_modules/@openzeppelin/docs-utils": {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,7 @@
     "security",
     "zeppelin"
   ],
-  "dependencies": {
-    "@openzeppelin/contracts": "^5.0.2",
-    "@openzeppelin/contracts-upgradeable": "^5.0.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
     "@nomicfoundation/hardhat-ethers": "^3.0.5",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,7 +1,3 @@
-@openzeppelin/contracts@v5/=node_modules/@openzeppelin/contracts/
-@openzeppelin/contracts-upgradeable@v5/=node_modules/@openzeppelin/contracts-upgradeable/
-
-@openzeppelin/contracts@master/=lib/@openzeppelin-contracts/contracts/
-@openzeppelin/contracts-upgradeable@master/=lib/@openzeppelin-contracts-upgradeable/contracts/
-
+@openzeppelin/contracts/=lib/@openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/@openzeppelin-contracts-upgradeable/contracts/
 @openzeppelin/community-contracts/=contracts/

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,10 +1,5 @@
 {
     "detectors_to_run": "arbitrary-send-erc20,array-by-reference,incorrect-shift,name-reused,rtlo,suicidal,uninitialized-state,uninitialized-storage,arbitrary-send-erc20-permit,controlled-array-length,controlled-delegatecall,delegatecall-loop,msg-value-loop,reentrancy-eth,unchecked-transfer,weak-prng,domain-separator-collision,erc20-interface,erc721-interface,locked-ether,mapping-deletion,shadowing-abstract,tautology,write-after-write,boolean-cst,reentrancy-no-eth,reused-constructor,tx-origin,unchecked-lowlevel,unchecked-send,variable-scope,void-cst,events-access,events-maths,incorrect-unary,boolean-equal,cyclomatic-complexity,deprecated-standards,erc20-indexed,function-init-state,pragma,unused-state,reentrancy-unlimited-gas,constable-states,immutable-states,var-read-using-this",
     "filter_paths": "contracts/mocks,contracts-exposed",
-    "compile_force_framework": "hardhat",
-    "solc_remaps": [
-        "@openzeppelin/contracts/=lib/@openzeppelin-contracts/contracts/",
-        "@openzeppelin/contracts-upgradeable/=lib/@openzeppelin-contracts-upgradeable/contracts/",
-        "@openzeppelin/community-contracts/=contracts/"
-    ]
+    "compile_force_framework": "hardhat"
 }

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,10 @@
 {
     "detectors_to_run": "arbitrary-send-erc20,array-by-reference,incorrect-shift,name-reused,rtlo,suicidal,uninitialized-state,uninitialized-storage,arbitrary-send-erc20-permit,controlled-array-length,controlled-delegatecall,delegatecall-loop,msg-value-loop,reentrancy-eth,unchecked-transfer,weak-prng,domain-separator-collision,erc20-interface,erc721-interface,locked-ether,mapping-deletion,shadowing-abstract,tautology,write-after-write,boolean-cst,reentrancy-no-eth,reused-constructor,tx-origin,unchecked-lowlevel,unchecked-send,variable-scope,void-cst,events-access,events-maths,incorrect-unary,boolean-equal,cyclomatic-complexity,deprecated-standards,erc20-indexed,function-init-state,pragma,unused-state,reentrancy-unlimited-gas,constable-states,immutable-states,var-read-using-this",
     "filter_paths": "contracts/mocks,contracts-exposed",
-    "compile_force_framework": "hardhat"
+    "compile_force_framework": "hardhat",
+    "solc_remaps": [
+        "@openzeppelin/contracts/=lib/@openzeppelin-contracts/contracts/",
+        "@openzeppelin/contracts-upgradeable/=lib/@openzeppelin-contracts-upgradeable/contracts/",
+        "@openzeppelin/community-contracts/=contracts/"
+    ]
 }

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,10 +1,4 @@
 {
     "detectors_to_run": "arbitrary-send-erc20,array-by-reference,incorrect-shift,name-reused,rtlo,suicidal,uninitialized-state,uninitialized-storage,arbitrary-send-erc20-permit,controlled-array-length,controlled-delegatecall,delegatecall-loop,msg-value-loop,reentrancy-eth,unchecked-transfer,weak-prng,domain-separator-collision,erc20-interface,erc721-interface,locked-ether,mapping-deletion,shadowing-abstract,tautology,write-after-write,boolean-cst,reentrancy-no-eth,reused-constructor,tx-origin,unchecked-lowlevel,unchecked-send,variable-scope,void-cst,events-access,events-maths,incorrect-unary,boolean-equal,cyclomatic-complexity,deprecated-standards,erc20-indexed,function-init-state,pragma,unused-state,reentrancy-unlimited-gas,constable-states,immutable-states,var-read-using-this",
-    "filter_paths": "contracts/mocks,contracts-exposed",
-    "compile_force_framework": "hardhat",
-    "solc_remaps": [
-        "@openzeppelin/contracts/=lib/@openzeppelin-contracts/contracts/",
-        "@openzeppelin/contracts-upgradeable/=lib/@openzeppelin-contracts-upgradeable/contracts/",
-        "@openzeppelin/community-contracts/=contracts/"
-    ]
+    "filter_paths": "contracts/mocks,contracts-exposed"
 }


### PR DESCRIPTION
### Motivation

Given the recent work in cross-chain and account abstraction, we've found that we would benefit from pointing to OpenZeppelin Contracts at `master`. The reasoning is that we can easily deliver small changes in libraries over there that are later used in this repository.

Otherwise, we would need to wait until an actual release before finishing the implementation in this side. This PR aims to simplify the remappings and remove npm dependencies to depend only in git submodules