### PR TITLE
Proposal to compress userOp.calldata encoding for `executeUserOp`

### DIFF
--- a/contracts/account/AccountCore.sol
+++ b/contracts/account/AccountCore.sol
@@ -91,10 +91,14 @@ abstract contract AccountCore is AbstractSigner, EIP712, IAccount, IAccountExecu
         PackedUserOperation calldata userOp,
         bytes32 /*userOpHash*/
     ) public virtual onlyEntryPointOrSelf {
+        // decode packed calldata
         address target = address(bytes20(userOp.callData[4:24]));
         uint256 value = uint256(bytes32(userOp.callData[24:56]));
         bytes calldata data = userOp.callData[56:];
-        Address.functionCallWithValue(target, data, value);
+
+        // we cannot use `Address.functionCallWithValue` here as it would revert on EOA targets
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        Address.verifyCallResult(success, returndata);
     }
 
     /**

--- a/contracts/account/AccountCore.sol
+++ b/contracts/account/AccountCore.sol
@@ -91,7 +91,9 @@ abstract contract AccountCore is AbstractSigner, EIP712, IAccount, IAccountExecu
         PackedUserOperation calldata userOp,
         bytes32 /*userOpHash*/
     ) public virtual onlyEntryPointOrSelf {
-        (address target, uint256 value, bytes memory data) = abi.decode(userOp.callData[4:], (address, uint256, bytes));
+        address target = address(bytes20(userOp.callData[4:24]));
+        uint256 value = uint256(bytes32(userOp.callData[24:56]));
+        bytes calldata data = userOp.callData[56:];
         Address.functionCallWithValue(target, data, value);
     }
 

--- a/test/account/Account.behavior.js
+++ b/test/account/Account.behavior.js
@@ -8,6 +8,10 @@ const {
   shouldSupportInterfaces,
 } = require('@openzeppelin/contracts/test/utils/introspection/SupportsInterface.behavior');
 
+const getAddress = account => ethers.getAddress(account.target ?? account.address ?? account);
+const encodeExecuteUserOp = (target, value, calldata) =>
+  ethers.solidityPacked(['address', 'uint256', 'bytes'], [getAddress(target), value ?? 0, calldata ?? '0x']);
+
 function shouldBehaveLikeAnAccountBase() {
   describe('entryPoint', function () {
     it('should return the canonical entrypoint', async function () {
@@ -28,10 +32,7 @@ function shouldBehaveLikeAnAccountBase() {
         .createUserOp({
           callData: ethers.concat([
             selector,
-            ethers.AbiCoder.defaultAbiCoder().encode(
-              ['address', 'uint256', 'bytes'],
-              [this.target.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')],
-            ),
+            encodeExecuteUserOp(this.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')),
           ]),
         })
         .then(op => this.signUserOp(op));
@@ -52,10 +53,7 @@ function shouldBehaveLikeAnAccountBase() {
           .createUserOp({
             callData: ethers.concat([
               selector,
-              ethers.AbiCoder.defaultAbiCoder().encode(
-                ['address', 'uint256', 'bytes'],
-                [this.target.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')],
-              ),
+              encodeExecuteUserOp(this.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')),
             ]),
           })
           .then(op => this.signUserOp(op));
@@ -72,10 +70,7 @@ function shouldBehaveLikeAnAccountBase() {
         const operation = await this.mock.createUserOp({
           callData: ethers.concat([
             selector,
-            ethers.AbiCoder.defaultAbiCoder().encode(
-              ['address', 'uint256', 'bytes'],
-              [this.target.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')],
-            ),
+            encodeExecuteUserOp(this.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')),
           ]),
         });
 
@@ -94,10 +89,7 @@ function shouldBehaveLikeAnAccountBase() {
           .createUserOp({
             callData: ethers.concat([
               selector,
-              ethers.AbiCoder.defaultAbiCoder().encode(
-                ['address', 'uint256', 'bytes'],
-                [this.target.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')],
-              ),
+              encodeExecuteUserOp(this.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')),
             ]),
           })
           .then(op => this.signUserOp(op));
@@ -212,10 +204,7 @@ function shouldBehaveLikeAnAccountBaseExecutor({ deployable = true } = {}) {
         .createUserOp({
           callData: ethers.concat([
             selector,
-            ethers.AbiCoder.defaultAbiCoder().encode(
-              ['address', 'uint256', 'bytes'],
-              [this.target.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')],
-            ),
+            encodeExecuteUserOp(this.target, 0, this.target.interface.encodeFunctionData('mockFunctionExtra')),
           ]),
         })
         .then(op => this.signUserOp(op));
@@ -233,10 +222,7 @@ function shouldBehaveLikeAnAccountBaseExecutor({ deployable = true } = {}) {
             .createUserOp({
               callData: ethers.concat([
                 selector,
-                ethers.AbiCoder.defaultAbiCoder().encode(
-                  ['address', 'uint256', 'bytes'],
-                  [this.target.target, 17, this.target.interface.encodeFunctionData('mockFunctionExtra')],
-                ),
+                encodeExecuteUserOp(this.target, 17, this.target.interface.encodeFunctionData('mockFunctionExtra')),
               ]),
             })
             .then(op => op.addInitCode())
@@ -256,10 +242,7 @@ function shouldBehaveLikeAnAccountBaseExecutor({ deployable = true } = {}) {
             .createUserOp({
               callData: ethers.concat([
                 selector,
-                ethers.AbiCoder.defaultAbiCoder().encode(
-                  ['address', 'uint256', 'bytes'],
-                  [this.target.target, 17, this.target.interface.encodeFunctionData('mockFunctionExtra')],
-                ),
+                encodeExecuteUserOp(this.target, 17, this.target.interface.encodeFunctionData('mockFunctionExtra')),
               ]),
             })
             .then(op => op.addInitCode());
@@ -282,9 +265,10 @@ function shouldBehaveLikeAnAccountBaseExecutor({ deployable = true } = {}) {
           .createUserOp({
             callData: ethers.concat([
               selector,
-              ethers.AbiCoder.defaultAbiCoder().encode(
-                ['address', 'uint256', 'bytes'],
-                [this.target.target, 42, this.target.interface.encodeFunctionData('mockFunctionExtra')],
+              encodeExecuteUserOp(
+                this.target.target,
+                42,
+                this.target.interface.encodeFunctionData('mockFunctionExtra'),
               ),
             ]),
           })


### PR DESCRIPTION
We can reduce the size of the useroperation by using a more compact encoding.

Also: fix part of #48 (sending eth to EOA) but may be override if we do the proposed change to delegatecall 

EDIT: full fix available in #49