### PR TITLE
Create local file for `.codecov.yml`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,15 @@
+comment: off
+github_checks:
+  annotations: false
+coverage:
+  status:
+    patch:
+      default:
+        target: 95%
+        only_pulls: true
+    project:
+      default:
+        threshold: 1%
+ignore:
+  - "test"
+  - "contracts/mocks"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,0 @@
-lib/@openzeppelin-contracts/.codecov.yml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > [!IMPORTANT]
 > This repository includes community-curated and experimental code that has not been audited and may introduce breaking changes at any time. We recommend
-> reviewing the [Security](#security) section  before using any code from this repository.
+> reviewing the [Security](#security) section before using any code from this repository.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > [!IMPORTANT]
 > This repository includes community-curated and experimental code that has not been audited and may introduce breaking changes at any time. We recommend
-> reviewing the [Security](#security) section before using any code from this repository.
+> reviewing the [Security](#security) section  before using any code from this repository.
 
 ## Overview
 


### PR DESCRIPTION
Codecov is not working correctly when using a symlink to the vanilla repo `.codecov.yml`. This deletes the symlink and adds the file locally.