### PR TITLE
Add husky to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@axelar-network/axelar-gmp-sdk-solidity": "^5.10.0"
       },
       "devDependencies": {
-        "@openzeppelin/contracts": "file:lib/@openzeppelin-contracts"
+        "@openzeppelin/contracts": "file:lib/@openzeppelin-contracts",
+        "husky": "^9.1.7"
       }
     },
     "lib/@openzeppelin-contracts": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@axelar-network/axelar-gmp-sdk-solidity": "^5.10.0"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "file:lib/@openzeppelin-contracts"
+    "@openzeppelin/contracts": "file:lib/@openzeppelin-contracts",
+    "husky": "^9.1.7"
   },
   "lint-staged": {
     "*.{js,ts}": [


### PR DESCRIPTION
package.json has `"prepare": "husky"`

Since this Community Contracts package is not yet published to NPM, consuming packages must install it through git.  According to [NPM's life cycle scripts](https://docs.npmjs.com/cli/v11/using-npm/scripts#life-cycle-scripts), the `prepare` script of this package must be run:
> NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.

Therefore `husky` should be declared as a `devDependency` so that this `prepare` script can be run by consumers.