### PR TITLE
Update link to ERC-7802 in ERC20Bridgeable

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20Bridgeable.sol
+++ b/contracts/token/ERC20/extensions/ERC20Bridgeable.sol
@@ -8,7 +8,7 @@ import {IERC7802} from "../../../interfaces/IERC7802.sol";
 
 /**
  * @dev ERC20 extension that implements the standard token interface according to
- * https://github.com/ethereum/ERCs/blob/bcea9feb6c3f3ded391e33690056635d722b101e/ERCS/erc-7802.md[ERC-7802].
+ * https://github.com/ethereum/ERCs/blob/master/ERCS/erc-7802.md[ERC-7802].
  *
  * NOTE: To implement a crosschain gateway for a chain, consider using an implementation if {IERC7786} token
  * bridge (e.g. {AxelarGatewaySource}, {AxelarGatewayDestination}).


### PR DESCRIPTION
ERC-7802 was merged to the ERCs repository, so the link can be updated to point to the one from master.