### PR TITLE
ERC-7913 signature verifier for ZKEmail

### DIFF
--- a/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
+++ b/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.20;
 
-import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
-
 import {IDKIMRegistry} from "@zk-email/contracts/DKIMRegistry.sol";
 import {IVerifier} from "@zk-email/email-tx-builder/interfaces/IVerifier.sol";
 import {EmailAuthMsg} from "@zk-email/email-tx-builder/interfaces/IEmailTypes.sol";

--- a/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
+++ b/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
@@ -11,7 +11,7 @@ import {ZKEmailUtils} from "./ZKEmailUtils.sol";
 /**
  * @dev ERC-7913 signature verifier that supports ZKEmail accounts.
  *
- * This verifier validates signatures produced through ZKEmail's zero-knowledge
+ * This contract verifies signatures produced through ZKEmail's zero-knowledge
  * proofs which allows users to authenticate using their email addresses.
  */
 abstract contract ERC7913SignatureVerifierZKEmail is IERC7913SignatureVerifier {
@@ -25,8 +25,10 @@ abstract contract ERC7913SignatureVerifierZKEmail is IERC7913SignatureVerifier {
         _templateId = templateId_;
     }
 
-    /// @dev An instance of the Verifier contract.
-    /// See https://docs.zk.email/architecture/zk-proofs#how-zk-email-uses-zero-knowledge-proofs[ZK Proofs].
+    /**
+     * @dev An instance of the Verifier contract.
+     * See https://docs.zk.email/architecture/zk-proofs#how-zk-email-uses-zero-knowledge-proofs[ZK Proofs].
+     */
     function verifier() public view virtual returns (IVerifier) {
         return _verifier;
     }

--- a/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
+++ b/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+import {IDKIMRegistry} from "@zk-email/contracts/DKIMRegistry.sol";
+import {IVerifier} from "@zk-email/email-tx-builder/interfaces/IVerifier.sol";
+import {EmailAuthMsg} from "@zk-email/email-tx-builder/interfaces/IEmailTypes.sol";
+import {IERC7913SignatureVerifier} from "../../interfaces/IERC7913.sol";
+import {ZKEmailUtils} from "./ZKEmailUtils.sol";
+
+/**
+ * @dev ERC-7913 signature verifier that support ZKEmail accounts.
+ */
+contract ERC7913SignatureVerifierZKEmail is IERC7913SignatureVerifier {
+    using ZKEmailUtils for EmailAuthMsg;
+
+    IVerifier public immutable verifier;
+    uint256 public immutable commandTemplate;
+
+    constructor(IVerifier _verifier, uint256 _commandTemplate) {
+        verifier = _verifier;
+        commandTemplate = _commandTemplate;
+    }
+
+    /// @inheritdoc IERC7913SignatureVerifier
+    function verify(bytes calldata key, bytes32 hash, bytes calldata signature) public view virtual returns (bytes4) {
+        (IDKIMRegistry registry, bytes32 accountSalt) = abi.decode(key, (IDKIMRegistry, bytes32));
+        EmailAuthMsg memory emailAuthMsg = abi.decode(signature, (EmailAuthMsg));
+        if (
+            bytes32(emailAuthMsg.commandParams[0]) == hash &&
+            emailAuthMsg.templateId == commandTemplate &&
+            emailAuthMsg.proof.accountSalt == accountSalt
+        ) {
+            (bool verified, ) = emailAuthMsg.isValidZKEmail(registry, verifier);
+            if (verified) {
+                return IERC7913SignatureVerifier.verify.selector;
+            }
+        }
+        return 0xffffffff;
+    }
+}

--- a/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
+++ b/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.24;
 
 import {IDKIMRegistry} from "@zk-email/contracts/DKIMRegistry.sol";
 import {IVerifier} from "@zk-email/email-tx-builder/interfaces/IVerifier.sol";

--- a/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
+++ b/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
@@ -9,29 +9,77 @@ import {IERC7913SignatureVerifier} from "../../interfaces/IERC7913.sol";
 import {ZKEmailUtils} from "./ZKEmailUtils.sol";
 
 /**
- * @dev ERC-7913 signature verifier that support ZKEmail accounts.
+ * @dev ERC-7913 signature verifier that supports ZKEmail accounts.
+ *
+ * This verifier validates signatures produced through ZKEmail's zero-knowledge
+ * proofs which allows users to authenticate using their email addresses.
  */
-contract ERC7913SignatureVerifierZKEmail is IERC7913SignatureVerifier {
+abstract contract ERC7913SignatureVerifierZKEmail is IERC7913SignatureVerifier {
     using ZKEmailUtils for EmailAuthMsg;
 
-    IVerifier public immutable verifier;
-    uint256 public immutable commandTemplate;
+    IVerifier private immutable _verifier;
+    uint256 private immutable _templateId;
 
-    constructor(IVerifier _verifier, uint256 _commandTemplate) {
-        verifier = _verifier;
-        commandTemplate = _commandTemplate;
+    constructor(IVerifier verifier_, uint256 templateId_) {
+        _verifier = verifier_;
+        _templateId = templateId_;
     }
 
-    /// @inheritdoc IERC7913SignatureVerifier
+    /// @dev An instance of the Verifier contract.
+    /// See https://docs.zk.email/architecture/zk-proofs#how-zk-email-uses-zero-knowledge-proofs[ZK Proofs].
+    function verifier() public view virtual returns (IVerifier) {
+        return _verifier;
+    }
+
+    /// @dev The command template of the sign hash command.
+    function templateId() public view virtual returns (uint256) {
+        return _templateId;
+    }
+
+    /**
+     * @dev Verifies a zero-knowledge proof of an email signature validated by a {DKIMRegistry} contract.
+     *
+     * The key format is ABI-encoded (IDKIMRegistry, bytes32) where:
+     * - IDKIMRegistry: The registry contract that validates DKIM public key hashes
+     * - bytes32: The account salt that uniquely identifies the user's email address
+     *
+     * The signature is an ABI-encoded {ZKEmailUtils-EmailAuthMsg} struct containing
+     * the command parameters, template ID, and proof details.
+     *
+     * Key encoding:
+     *
+     * ```solidity
+     * bytes memory key = abi.encode(registry, accountSalt);
+     * ```
+     *
+     * Signature encoding:
+     *
+     * ```solidity
+     * bytes memory signature = abi.encode(EmailAuthMsg({
+     *     templateId: 1,
+     *     commandParams: [hash],
+     *     proof: {
+     *         domainName: "example.com", // The domain name of the email sender
+     *         publicKeyHash: bytes32(0x...), // Hash of the DKIM public key used to sign the email
+     *         timestamp: block.timestamp, // When the email was sent
+     *         maskedCommand: "Sign hash", // The command being executed, with sensitive data masked
+     *         emailNullifier: bytes32(0x...), // Unique identifier for the email to prevent replay attacks
+     *         accountSalt: bytes32(0x...), // Unique identifier derived from email and account code
+     *         isCodeExist: true, // Whether the account code exists in the proof
+     *         proof: bytes(0x...) // The zero-knowledge proof verifying the email's authenticity
+     *     }
+     * }));
+     * ```
+     */
     function verify(bytes calldata key, bytes32 hash, bytes calldata signature) public view virtual returns (bytes4) {
         (IDKIMRegistry registry, bytes32 accountSalt) = abi.decode(key, (IDKIMRegistry, bytes32));
         EmailAuthMsg memory emailAuthMsg = abi.decode(signature, (EmailAuthMsg));
 
         return
             (abi.decode(emailAuthMsg.commandParams[0], (bytes32)) == hash &&
-                emailAuthMsg.templateId == commandTemplate &&
+                emailAuthMsg.templateId == templateId() &&
                 emailAuthMsg.proof.accountSalt == accountSalt &&
-                emailAuthMsg.isValidZKEmail(registry, verifier) == ZKEmailUtils.EmailProofError.NoError)
+                emailAuthMsg.isValidZKEmail(registry, verifier()) == ZKEmailUtils.EmailProofError.NoError)
                 ? IERC7913SignatureVerifier.verify.selector
                 : bytes4(0xffffffff);
     }

--- a/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
+++ b/contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol
@@ -26,16 +26,13 @@ contract ERC7913SignatureVerifierZKEmail is IERC7913SignatureVerifier {
     function verify(bytes calldata key, bytes32 hash, bytes calldata signature) public view virtual returns (bytes4) {
         (IDKIMRegistry registry, bytes32 accountSalt) = abi.decode(key, (IDKIMRegistry, bytes32));
         EmailAuthMsg memory emailAuthMsg = abi.decode(signature, (EmailAuthMsg));
-        if (
-            bytes32(emailAuthMsg.commandParams[0]) == hash &&
-            emailAuthMsg.templateId == commandTemplate &&
-            emailAuthMsg.proof.accountSalt == accountSalt
-        ) {
-            (bool verified, ) = emailAuthMsg.isValidZKEmail(registry, verifier);
-            if (verified) {
-                return IERC7913SignatureVerifier.verify.selector;
-            }
-        }
-        return 0xffffffff;
+
+        return
+            (abi.decode(emailAuthMsg.commandParams[0], (bytes32)) == hash &&
+                emailAuthMsg.templateId == commandTemplate &&
+                emailAuthMsg.proof.accountSalt == accountSalt &&
+                emailAuthMsg.isValidZKEmail(registry, verifier) == ZKEmailUtils.EmailProofError.NoError)
+                ? IERC7913SignatureVerifier.verify.selector
+                : bytes4(0xffffffff);
     }
 }

--- a/contracts/utils/cryptography/SignerZKEmail.sol
+++ b/contracts/utils/cryptography/SignerZKEmail.sol
@@ -81,8 +81,10 @@ abstract contract SignerZKEmail is AbstractSigner {
         return _registry;
     }
 
-    /// @dev An instance of the Verifier contract.
-    /// See https://docs.zk.email/architecture/zk-proofs#how-zk-email-uses-zero-knowledge-proofs[ZK Proofs].
+    /**
+     * @dev An instance of the Verifier contract.
+     * See https://docs.zk.email/architecture/zk-proofs#how-zk-email-uses-zero-knowledge-proofs[ZK Proofs].
+     */
     function verifier() public view virtual returns (IVerifier) {
         return _verifier;
     }

--- a/test/account/AccountERC7913.test.js
+++ b/test/account/AccountERC7913.test.js
@@ -3,7 +3,7 @@ const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 
 const { getDomain } = require('@openzeppelin/contracts/test/helpers/eip712');
 const { ERC4337Helper } = require('../helpers/erc4337');
-const { NonNativeSigner, P256SigningKey, RSASHA256SigningKey } = require('../helpers/signers');
+const { NonNativeSigner, P256SigningKey, RSASHA256SigningKey, ZKEmailSigningKey } = require('../helpers/signers');
 const { PackedUserOperation } = require('../helpers/eip712-types');
 
 const { shouldBehaveLikeAccountCore, shouldBehaveLikeAccountHolder } = require('./Account.behavior');
@@ -15,15 +15,39 @@ const signerECDSA = ethers.Wallet.createRandom();
 const signerP256 = new NonNativeSigner(P256SigningKey.random());
 const signerRSA = new NonNativeSigner(RSASHA256SigningKey.random());
 
+// Constants for ZKEmail
+const accountSalt = '0x046582bce36cdd0a8953b9d40b8f20d58302bacf3bcecffeb6741c98a52725e2'; // keccak256("test@example.com")
+const selector = '12345';
+const domainName = 'gmail.com';
+const publicKeyHash = '0x0ea9c777dc7110e5a9e89b13f0cfc540e3845ba120b2b6dc24024d61488d4788';
+const emailNullifier = '0x00a83fce3d4b1c9ef0f600644c1ecc6c8115b57b1596e0e3295e2c5105fbfd8a';
+const templateId = ethers.solidityPackedKeccak256(['string', 'uint256'], ['TEST', 0n]);
+
 // Minimal fixture common to the different signer verifiers
 async function fixture() {
   // EOAs and environment
-  const [beneficiary, other] = await ethers.getSigners();
+  const [admin, beneficiary, other] = await ethers.getSigners();
   const target = await ethers.deployContract('CallReceiverMockExtended');
+
+  // DKIM Registry for ZKEmail
+  const dkim = await ethers.deployContract('ECDSAOwnedDKIMRegistry');
+  await dkim.initialize(admin, admin);
+  await dkim
+    .SET_PREFIX()
+    .then(prefix => dkim.computeSignedMsg(prefix, domainName, publicKeyHash))
+    .then(message => admin.signMessage(message))
+    .then(signature => dkim.setDKIMPublicKeyHash(selector, domainName, publicKeyHash, signature));
+
+  // ZKEmail Verifier
+  const zkEmailVerifier = await ethers.deployContract('ZKEmailVerifierMock');
 
   // ERC-7913 verifiers
   const verifierP256 = await ethers.deployContract('ERC7913SignatureVerifierP256');
   const verifierRSA = await ethers.deployContract('ERC7913SignatureVerifierRSA');
+  const verifierZKEmail = await ethers.deployContract('$ERC7913SignatureVerifierZKEmail', [
+    zkEmailVerifier.target,
+    templateId,
+  ]);
 
   // ERC-4337 env
   const helper = new ERC4337Helper();
@@ -43,7 +67,20 @@ async function fixture() {
       .then(signature => Object.assign(userOp, { signature }));
   };
 
-  return { helper, verifierP256, verifierRSA, domain, target, beneficiary, other, makeMock, signUserOp };
+  return {
+    helper,
+    verifierP256,
+    verifierRSA,
+    verifierZKEmail,
+    dkim,
+    zkEmailVerifier,
+    domain,
+    target,
+    beneficiary,
+    other,
+    makeMock,
+    signUserOp,
+  };
 }
 
 describe('AccountERC7913', function () {
@@ -96,6 +133,35 @@ describe('AccountERC7913', function () {
           ),
         ]),
       );
+    });
+
+    shouldBehaveLikeAccountCore();
+    shouldBehaveLikeAccountHolder();
+    shouldBehaveLikeERC1271({ erc7739: true });
+    shouldBehaveLikeERC7821();
+  });
+
+  // Using ZKEmail with an ERC-7913 verifier
+  describe('ZKEmail', function () {
+    beforeEach(async function () {
+      // Create ZKEmail signer
+      this.signer = new NonNativeSigner(
+        new ZKEmailSigningKey(domainName, publicKeyHash, emailNullifier, accountSalt, templateId),
+      );
+
+      // Create account with ZKEmail verifier
+      this.mock = await this.makeMock(
+        ethers.concat([
+          this.verifierZKEmail.target,
+          ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bytes32'], [this.dkim.target, accountSalt]),
+        ]),
+      );
+
+      // Override the signUserOp function to use the ZKEmail signer
+      this.signUserOp = async userOp => {
+        const hash = await userOp.hash();
+        return Object.assign(userOp, { signature: this.signer.signingKey.sign(hash).serialized });
+      };
     });
 
     shouldBehaveLikeAccountCore();

--- a/test/account/AccountERC7913.test.js
+++ b/test/account/AccountERC7913.test.js
@@ -44,10 +44,7 @@ async function fixture() {
   // ERC-7913 verifiers
   const verifierP256 = await ethers.deployContract('ERC7913SignatureVerifierP256');
   const verifierRSA = await ethers.deployContract('ERC7913SignatureVerifierRSA');
-  const verifierZKEmail = await ethers.deployContract('$ERC7913SignatureVerifierZKEmail', [
-    zkEmailVerifier.target,
-    templateId,
-  ]);
+  const verifierZKEmail = await ethers.deployContract('$ERC7913SignatureVerifierZKEmail');
 
   // ERC-4337 env
   const helper = new ERC4337Helper();
@@ -153,7 +150,10 @@ describe('AccountERC7913', function () {
       this.mock = await this.makeMock(
         ethers.concat([
           this.verifierZKEmail.target,
-          ethers.AbiCoder.defaultAbiCoder().encode(['address', 'bytes32'], [this.dkim.target, accountSalt]),
+          ethers.AbiCoder.defaultAbiCoder().encode(
+            ['address', 'bytes32', 'address', 'uint256'],
+            [this.dkim.target, accountSalt, this.zkEmailVerifier.target, templateId],
+          ),
         ]),
       );
 


### PR DESCRIPTION
Based on #96 and #98

The relevant file here is `contracts/utils/cryptography/ERC7913SignatureVerifierZKEmail.sol`