### PR TITLE
Remove `Arrays` library usage from `EnumerableSetExtended`

### DIFF
--- a/contracts/utils/structs/EnumerableSetExtended.sol
+++ b/contracts/utils/structs/EnumerableSetExtended.sol
@@ -3,7 +3,6 @@
 
 pragma solidity ^0.8.20;
 
-import {Arrays} from "@openzeppelin/contracts/utils/Arrays.sol";
 import {Hashes} from "@openzeppelin/contracts/utils/cryptography/Hashes.sol";
 
 /**
@@ -121,7 +120,19 @@ library EnumerableSetExtended {
         for (uint256 i = 0; i < len; ++i) {
             delete set._positions[set._values[i]];
         }
-        Arrays.unsafeSetLength(set._values, 0);
+        unsafeSetLength(set._values, 0);
+    }
+
+    /**
+     * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
+     *
+     * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
+     */
+    // Replace when these are available in Arrays.sol
+    function unsafeSetLength(string[] storage array, uint256 len) internal {
+        assembly ("memory-safe") {
+            sstore(array.slot, len)
+        }
     }
 
     /**
@@ -241,7 +252,19 @@ library EnumerableSetExtended {
         for (uint256 i = 0; i < len; ++i) {
             delete set._positions[set._values[i]];
         }
-        Arrays.unsafeSetLength(set._values, 0);
+        unsafeSetLength(set._values, 0);
+    }
+
+    /**
+     * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
+     *
+     * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
+     */
+    // Replace when these are available in Arrays.sol
+    function unsafeSetLength(bytes[] storage array, uint256 len) internal {
+        assembly ("memory-safe") {
+            sstore(array.slot, len)
+        }
     }
 
     /**

--- a/contracts/utils/structs/EnumerableSetExtended.sol
+++ b/contracts/utils/structs/EnumerableSetExtended.sol
@@ -120,16 +120,8 @@ library EnumerableSetExtended {
         for (uint256 i = 0; i < len; ++i) {
             delete set._positions[set._values[i]];
         }
-        unsafeSetLength(set._values, 0);
-    }
-
-    /**
-     * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
-     *
-     * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
-     */
-    // Replace when these are available in Arrays.sol
-    function unsafeSetLength(string[] storage array, uint256 len) internal {
+        // Replace when these are available in Arrays.sol
+        string[] storage array = set._values;
         assembly ("memory-safe") {
             sstore(array.slot, len)
         }
@@ -252,16 +244,8 @@ library EnumerableSetExtended {
         for (uint256 i = 0; i < len; ++i) {
             delete set._positions[set._values[i]];
         }
-        unsafeSetLength(set._values, 0);
-    }
-
-    /**
-     * @dev Helper to set the length of a dynamic array. Directly writing to `.length` is forbidden.
-     *
-     * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
-     */
-    // Replace when these are available in Arrays.sol
-    function unsafeSetLength(bytes[] storage array, uint256 len) internal {
+        // Replace when these are available in Arrays.sol
+        bytes[] storage array = set._values;
         assembly ("memory-safe") {
             sstore(array.slot, len)
         }

--- a/contracts/utils/structs/EnumerableSetExtended.sol
+++ b/contracts/utils/structs/EnumerableSetExtended.sol
@@ -123,7 +123,7 @@ library EnumerableSetExtended {
         // Replace when these are available in Arrays.sol
         string[] storage array = set._values;
         assembly ("memory-safe") {
-            sstore(array.slot, len)
+            sstore(array.slot, 0)
         }
     }
 
@@ -247,7 +247,7 @@ library EnumerableSetExtended {
         // Replace when these are available in Arrays.sol
         bytes[] storage array = set._values;
         assembly ("memory-safe") {
-            sstore(array.slot, len)
+            sstore(array.slot, 0)
         }
     }
 

--- a/scripts/generate/templates/Enumerable.opts.js
+++ b/scripts/generate/templates/Enumerable.opts.js
@@ -11,6 +11,7 @@ const typeDescr = ({ type, size = 0, memory = false }) => {
 };
 
 const toSetTypeDescr = value => ({
+  underlying: value.name.toLowerCase(),
   name: value.name + 'Set',
   value,
 });

--- a/scripts/generate/templates/Enumerable.opts.js
+++ b/scripts/generate/templates/Enumerable.opts.js
@@ -11,7 +11,6 @@ const typeDescr = ({ type, size = 0, memory = false }) => {
 };
 
 const toSetTypeDescr = value => ({
-  underlying: value.name.toLowerCase(),
   name: value.name + 'Set',
   value,
 });

--- a/scripts/generate/templates/EnumerableSetExtended.js
+++ b/scripts/generate/templates/EnumerableSetExtended.js
@@ -45,7 +45,7 @@ import {Hashes} from "@openzeppelin/contracts/utils/cryptography/Hashes.sol";
  */
 `;
 
-const set = ({ underlying, name, value }) => `\
+const set = ({ name, value }) => `\
 struct ${name} {
     // Storage of set values
     ${value.type}[] _values;
@@ -123,16 +123,8 @@ function clear(${name} storage set) internal {
     for (uint256 i = 0; i < len; ++i) {
         delete set._positions[set._values[i]];
     }
-    unsafeSetLength(set._values, 0);
-}
-
-/**
- * @dev Helper to set the length of a dynamic array. Directly writing to \`.length\` is forbidden.
- * 
- * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
- */
-// Replace when these are available in Arrays.sol
-function unsafeSetLength(${underlying}[] storage array, uint256 len) internal {
+    // Replace when these are available in Arrays.sol
+    ${value.type}[] storage array = set._values;
     assembly ("memory-safe") {
         sstore(array.slot, len)
     }

--- a/scripts/generate/templates/EnumerableSetExtended.js
+++ b/scripts/generate/templates/EnumerableSetExtended.js
@@ -4,7 +4,6 @@ const { SET_TYPES } = require('./Enumerable.opts');
 const header = `\
 pragma solidity ^0.8.20;
 
-import {Arrays} from "@openzeppelin/contracts/utils/Arrays.sol";
 import {Hashes} from "@openzeppelin/contracts/utils/cryptography/Hashes.sol";
 
 /**
@@ -46,7 +45,7 @@ import {Hashes} from "@openzeppelin/contracts/utils/cryptography/Hashes.sol";
  */
 `;
 
-const set = ({ name, value }) => `\
+const set = ({ underlying, name, value }) => `\
 struct ${name} {
     // Storage of set values
     ${value.type}[] _values;
@@ -124,7 +123,19 @@ function clear(${name} storage set) internal {
     for (uint256 i = 0; i < len; ++i) {
         delete set._positions[set._values[i]];
     }
-    Arrays.unsafeSetLength(set._values, 0);
+    unsafeSetLength(set._values, 0);
+}
+
+/**
+ * @dev Helper to set the length of a dynamic array. Directly writing to \`.length\` is forbidden.
+ * 
+ * WARNING: this does not clear elements if length is reduced, of initialize elements if length is increased.
+ */
+// Replace when these are available in Arrays.sol
+function unsafeSetLength(${underlying}[] storage array, uint256 len) internal {
+    assembly ("memory-safe") {
+        sstore(array.slot, len)
+    }
 }
 
 /**

--- a/scripts/generate/templates/EnumerableSetExtended.js
+++ b/scripts/generate/templates/EnumerableSetExtended.js
@@ -126,7 +126,7 @@ function clear(${name} storage set) internal {
     // Replace when these are available in Arrays.sol
     ${value.type}[] storage array = set._values;
     assembly ("memory-safe") {
-        sstore(array.slot, len)
+        sstore(array.slot, 0)
     }
 }
 


### PR DESCRIPTION
### Description

Unfortunately, https://github.com/OpenZeppelin/openzeppelin-contracts/commit/8a4eadea51028d1d8c6eb4252e3248b08a43a740 didn't make it into the 5.3.0 release, which makes available some changes needed for the `EnumerableSetExtended` library. Concretely, the `unsafeSetLength` functions are not available to users.

As a result, https://github.com/OpenZeppelin/contracts-wizard/pull/527 do not compile. This PR addresses the issue by temporarily porting the missing features in 5.3.0