### PR TITLE
Move `dependencies` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "security",
     "zeppelin"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@axelar-network/axelar-gmp-sdk-solidity": "^6.0.6",
     "@zk-email/contracts": "^6.3.2"
   },


### PR DESCRIPTION
This will avoid wizard to install unnecessary dependencies and all the subdependencies that come with them