### PR TITLE
Change ERC-7913 title category in utilities docs

### DIFF
--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -35,7 +35,7 @@ In case your smart contract validates signatures, using xref:api:utils.adoc#ERC7
 include::api:example$utils/cryptography/ERC7739SignerECDSA.sol[]
 ----
 
-==== ERC-7913 Signature Verifiers
+=== ERC-7913 Signature Verifiers
 
 ERC-7913 extends the concept of signature verification to support keys that don't have their own Ethereum address. This is particularly useful for integrating non-Ethereum cryptographic curves, hardware devices, or other identity systems into smart accounts.
 


### PR DESCRIPTION
### Description

This makes the ERC-7913 verifiers to show its own section on the sidebar menu. This is also the correct way to do it since it doesn't belong to the "typed signatures" category