### PR TITLE
Move `areValidNSignaturesNow` to `ERC7913Utils`

### DIFF
--- a/contracts/mocks/ERC7913VerifierMock.sol
+++ b/contracts/mocks/ERC7913VerifierMock.sol
@@ -16,13 +16,22 @@ contract ERC7913VerifierMock is IERC7913SignatureVerifier {
     }
 
     function verify(bytes calldata key, bytes32 /* hash */, bytes calldata signature) external pure returns (bytes4) {
-        // For testing purposes, we'll only accept a specific key and signature combination
-        if (
-            keccak256(key) == keccak256(abi.encodePacked("valid_key")) &&
-            keccak256(signature) == keccak256(abi.encodePacked("valid_signature"))
-        ) {
+        // For testing purposes, we'll only accept specific key/signature combinations
+        if (_isKnownSigner1(key, signature) || _isKnownSigner2(key, signature)) {
             return IERC7913SignatureVerifier.verify.selector;
         }
         return 0xffffffff;
+    }
+
+    function _isKnownSigner1(bytes calldata key, bytes calldata signature) internal pure returns (bool) {
+        return
+            keccak256(key) == keccak256(abi.encodePacked("valid_key_1")) &&
+            keccak256(signature) == keccak256(abi.encodePacked("valid_signature_1"));
+    }
+
+    function _isKnownSigner2(bytes calldata key, bytes calldata signature) internal pure returns (bool) {
+        return
+            keccak256(key) == keccak256(abi.encodePacked("valid_key_2")) &&
+            keccak256(signature) == keccak256(abi.encodePacked("valid_signature_2"));
     }
 }

--- a/contracts/utils/cryptography/ERC7913Utils.sol
+++ b/contracts/utils/cryptography/ERC7913Utils.sol
@@ -84,4 +84,18 @@ library ERC7913Utils {
 
         return true;
     }
+
+    /// @dev Overload of {isValidNSignaturesNow} that uses the `keccak256` as the `signerId` function.
+    function isValidNSignaturesNow(
+        bytes32 hash,
+        bytes[] memory signers,
+        bytes[] memory signatures
+    ) internal view returns (bool) {
+        return isValidNSignaturesNow(hash, signers, signatures, _keccak256);
+    }
+
+    /// @dev Computes the keccak256 hash of the given data.
+    function _keccak256(bytes memory data) private pure returns (bytes32) {
+        return keccak256(data);
+    }
 }

--- a/contracts/utils/cryptography/ERC7913Utils.sol
+++ b/contracts/utils/cryptography/ERC7913Utils.sol
@@ -62,7 +62,7 @@ library ERC7913Utils {
      * NOTE: The `signerId` function argument must be deterministic and should not manipulate
      * memory state directly and should follow Solidity memory safety rules to avoid unexpected behavior.
      */
-    function isValidNSignaturesNow(
+    function areValidNSignaturesNow(
         bytes32 hash,
         bytes[] memory signers,
         bytes[] memory signatures,
@@ -85,13 +85,13 @@ library ERC7913Utils {
         return true;
     }
 
-    /// @dev Overload of {isValidNSignaturesNow} that uses the `keccak256` as the `signerId` function.
-    function isValidNSignaturesNow(
+    /// @dev Overload of {areValidNSignaturesNow} that uses the `keccak256` as the `signerId` function.
+    function areValidNSignaturesNow(
         bytes32 hash,
         bytes[] memory signers,
         bytes[] memory signatures
     ) internal view returns (bool) {
-        return isValidNSignaturesNow(hash, signers, signatures, _keccak256);
+        return areValidNSignaturesNow(hash, signers, signatures, _keccak256);
     }
 
     /// @dev Computes the keccak256 hash of the given data.

--- a/contracts/utils/cryptography/ERC7913Utils.sol
+++ b/contracts/utils/cryptography/ERC7913Utils.sol
@@ -48,4 +48,40 @@ library ERC7913Utils {
                 abi.decode(result, (bytes32)) == bytes32(IERC7913SignatureVerifier.verify.selector));
         }
     }
+
+    /**
+     * @dev Verifies multiple `signatures` for a given hash using a set of `signers`.
+     *
+     * The signers must be ordered by their `signerId` to ensure no duplicates and to optimize
+     * the verification process. The function will return `false` if the signers are not properly ordered.
+     *
+     * Requirements:
+     *
+     * * The `signatures` array must be at least the  `signers` array's length.
+     *
+     * NOTE: The `signerId` function argument must be deterministic and should not manipulate
+     * memory state directly and should follow Solidity memory safety rules to avoid unexpected behavior.
+     */
+    function isValidNSignaturesNow(
+        bytes32 hash,
+        bytes[] memory signers,
+        bytes[] memory signatures,
+        function(bytes memory) view returns (bytes32) signerId
+    ) internal view returns (bool) {
+        bytes32 currentSignerId = bytes32(0);
+
+        uint256 signersLength = signers.length;
+        for (uint256 i = 0; i < signersLength; i++) {
+            bytes memory signer = signers[i];
+            // Signers must ordered by id to ensure no duplicates
+            bytes32 id = signerId(signer);
+            if (currentSignerId >= id || !isValidSignatureNow(signer, hash, signatures[i])) {
+                return false;
+            }
+
+            currentSignerId = id;
+        }
+
+        return true;
+    }
 }

--- a/contracts/utils/cryptography/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/MultiSignerERC7913.sol
@@ -204,7 +204,7 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
                 return false;
             }
         }
-        return hash.isValidNSignaturesNow(signingSigners, signatures, signerId);
+        return hash.areValidNSignaturesNow(signingSigners, signatures, signerId);
     }
 
     /**

--- a/contracts/utils/cryptography/MultiSignerERC7913.sol
+++ b/contracts/utils/cryptography/MultiSignerERC7913.sol
@@ -47,7 +47,7 @@ import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
  */
 abstract contract MultiSignerERC7913 is AbstractSigner {
     using EnumerableSetExtended for EnumerableSetExtended.BytesSet;
-    using ERC7913Utils for bytes;
+    using ERC7913Utils for *;
     using SafeCast for uint256;
 
     EnumerableSetExtended.BytesSet private _signersSet;
@@ -198,21 +198,13 @@ abstract contract MultiSignerERC7913 is AbstractSigner {
         bytes[] memory signingSigners,
         bytes[] memory signatures
     ) internal view virtual returns (bool valid) {
-        bytes32 currentSignerId = bytes32(0);
-
         uint256 signersLength = signingSigners.length;
         for (uint256 i = 0; i < signersLength; i++) {
-            // Signers must ordered by id to ensure no duplicates
-            bytes memory signer = signingSigners[i];
-            bytes32 id = signerId(signer);
-            if (currentSignerId >= id || !isSigner(signer) || !signer.isValidSignatureNow(hash, signatures[i])) {
+            if (!isSigner(signingSigners[i])) {
                 return false;
             }
-
-            currentSignerId = id;
         }
-
-        return true;
+        return hash.isValidNSignaturesNow(signingSigners, signatures, signerId);
     }
 
     /**

--- a/test/utils/cryptography/ERC7913Utils.test.js
+++ b/test/utils/cryptography/ERC7913Utils.test.js
@@ -153,9 +153,9 @@ describe('ERC7913Utils', function () {
     });
   });
 
-  describe('isValidNSignaturesNow', function () {
+  describe('areValidNSignaturesNow', function () {
     it('should validate a single signature', async function () {
-      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, [this.eoaSigner], [this.eoaSignature])).to
+      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, [this.eoaSigner], [this.eoaSignature])).to
         .eventually.be.true;
     });
 
@@ -181,7 +181,7 @@ describe('ERC7913Utils', function () {
         return ethers.randomBytes(65); // fallback, shouldn't be reached
       });
 
-      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
     });
 
     it('should validate multiple EOA signatures', async function () {
@@ -196,7 +196,7 @@ describe('ERC7913Utils', function () {
 
       const signatures = signers.map(signer => signatureMap[ethers.hexlify(signer)]);
 
-      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
     });
 
     it('should validate multiple ERC-1271 wallet signatures', async function () {
@@ -209,7 +209,7 @@ describe('ERC7913Utils', function () {
         signatures.reverse();
       }
 
-      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
     });
 
     it('should validate multiple ERC-7913 signatures', async function () {
@@ -226,13 +226,13 @@ describe('ERC7913Utils', function () {
 
       const signatures = signers.map(signer => signatureMap[ethers.hexlify(signer)]);
 
-      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
     });
 
     it('should return false if any signature is invalid', async function () {
       // Use two EOA signers but one signature is for the wrong message
       await expect(
-        this.mock.$isValidNSignaturesNow(
+        this.mock.$areValidNSignaturesNow(
           TEST_MESSAGE_HASH,
           [this.eoaSigner, this.eoaSigner2],
           [this.eoaSignature, this.wrongMessageSignature],
@@ -251,12 +251,12 @@ describe('ERC7913Utils', function () {
         signatures.reverse();
       }
 
-      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.false;
+      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.false;
     });
 
     it('should return false if there are duplicate signers', async function () {
       await expect(
-        this.mock.$isValidNSignaturesNow(
+        this.mock.$areValidNSignaturesNow(
           TEST_MESSAGE_HASH,
           [this.eoaSigner, this.eoaSigner], // Same signer used twice
           [this.eoaSignature, this.eoaSignature],
@@ -266,7 +266,7 @@ describe('ERC7913Utils', function () {
 
     it('should fail if signatures array length does not match signers array length', async function () {
       await expect(
-        this.mock.$isValidNSignaturesNow(
+        this.mock.$areValidNSignaturesNow(
           TEST_MESSAGE_HASH,
           [this.eoaSigner, this.eoaSigner2],
           [this.eoaSignature], // Missing one signature
@@ -275,7 +275,7 @@ describe('ERC7913Utils', function () {
     });
 
     it('should pass with empty arrays', async function () {
-      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, [], [])).to.eventually.be.true;
+      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, [], [])).to.eventually.be.true;
     });
   });
 });

--- a/test/utils/cryptography/ERC7913Utils.test.js
+++ b/test/utils/cryptography/ERC7913Utils.test.js
@@ -3,11 +3,11 @@ const { ethers } = require('hardhat');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
 const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
-const TEST_MESSAGE = ethers.id('OpenZeppelin');
-const TEST_MESSAGE_HASH = ethers.hashMessage(TEST_MESSAGE);
+const VALID_SW_KEY_1 = ethers.toUtf8Bytes('valid_key_1');
+const VALID_SW_KEY_2 = ethers.toUtf8Bytes('valid_key_2');
 
-const WRONG_MESSAGE = ethers.id('Nope');
-const WRONG_MESSAGE_HASH = ethers.hashMessage(WRONG_MESSAGE);
+const VALID_SW_SIGNATURE_1 = ethers.toUtf8Bytes('valid_signature_1');
+const VALID_SW_SIGNATURE_2 = ethers.toUtf8Bytes('valid_signature_2');
 
 async function fixture() {
   const [, signer, other, extraSigner] = await ethers.getSigners();
@@ -20,60 +20,14 @@ async function fixture() {
   // Deploy a mock ERC-7913 verifier
   const verifier = await ethers.deployContract('ERC7913VerifierMock');
 
-  // Create test keys
-  const validKey = ethers.toUtf8Bytes('valid_key_1');
-  const validKey2 = ethers.toUtf8Bytes('valid_key_2');
-  const invalidKey = ethers.randomBytes(32);
-
-  // Create signer bytes (verifier address + key)
-  const validSignerBytes = ethers.concat([verifier.target, validKey]);
-  const validSignerBytes2 = ethers.concat([verifier.target, validKey2]);
-  const invalidKeySignerBytes = ethers.concat([verifier.target, invalidKey]);
-
-  // Create test signatures
-  const validSignature = ethers.toUtf8Bytes('valid_signature_1');
-  const validSignature2 = ethers.toUtf8Bytes('valid_signature_2');
-  const invalidSignature = ethers.randomBytes(65);
-
-  // Get EOA signatures from the signers
-  const eoaSignature = await signer.signMessage(TEST_MESSAGE);
-  const eoaSignature2 = await extraSigner.signMessage(TEST_MESSAGE);
-  const wrongMessageSignature = await signer.signMessage(WRONG_MESSAGE);
-
-  // Create EOA signers
-  const eoaSigner = ethers.zeroPadValue(signer.address, 20);
-  const eoaSigner2 = ethers.zeroPadValue(extraSigner.address, 20);
-  const wrongSigner = ethers.zeroPadValue(other.address, 20);
-
-  // Create Wallet signers
-  const walletSigner = ethers.zeroPadValue(wallet.target, 20);
-  const walletSigner2 = ethers.zeroPadValue(wallet2.target, 20);
-
   return {
     signer,
-    other,
     extraSigner,
+    other,
     mock,
     wallet,
     wallet2,
     verifier,
-    validKey,
-    validKey2,
-    invalidKey,
-    validSignerBytes,
-    validSignerBytes2,
-    invalidKeySignerBytes,
-    validSignature,
-    validSignature2,
-    invalidSignature,
-    eoaSignature,
-    eoaSignature2,
-    wrongMessageSignature,
-    eoaSigner,
-    eoaSigner2,
-    wrongSigner,
-    walletSigner,
-    walletSigner2,
   };
 }
 
@@ -86,19 +40,24 @@ describe('ERC7913Utils', function () {
     describe('with EOA signer', function () {
       it('with matching signer and signature', async function () {
         const eoaSigner = ethers.zeroPadValue(this.signer.address, 20);
-        await expect(this.mock.$isValidSignatureNow(eoaSigner, TEST_MESSAGE_HASH, this.eoaSignature)).to.eventually.be
+        const message = 'Hello, World!';
+        const signature = await this.signer.signMessage(message);
+        await expect(this.mock.$isValidSignatureNow(eoaSigner, ethers.hashMessage(message), signature)).to.eventually.be
           .true;
       });
 
       it('with invalid signer', async function () {
         const eoaSigner = ethers.zeroPadValue(this.other.address, 20);
-        await expect(this.mock.$isValidSignatureNow(eoaSigner, TEST_MESSAGE_HASH, this.eoaSignature)).to.eventually.be
+        const message = 'Hello, World!';
+        const signature = await this.signer.signMessage(message);
+        await expect(this.mock.$isValidSignatureNow(eoaSigner, ethers.hashMessage(message), signature)).to.eventually.be
           .false;
       });
 
       it('with invalid signature', async function () {
         const eoaSigner = ethers.zeroPadValue(this.signer.address, 20);
-        await expect(this.mock.$isValidSignatureNow(eoaSigner, WRONG_MESSAGE_HASH, this.eoaSignature)).to.eventually.be
+        const signature = await this.signer.signMessage('Hello, World!');
+        await expect(this.mock.$isValidSignatureNow(eoaSigner, ethers.hashMessage('Nope'), signature)).to.eventually.be
           .false;
       });
     });
@@ -106,176 +65,194 @@ describe('ERC7913Utils', function () {
     describe('with ERC-1271 wallet', function () {
       it('with matching signer and signature', async function () {
         const walletSigner = ethers.zeroPadValue(this.wallet.target, 20);
-        await expect(this.mock.$isValidSignatureNow(walletSigner, TEST_MESSAGE_HASH, this.eoaSignature)).to.eventually
+        const message = 'Hello, World!';
+        const signature = await this.signer.signMessage(message);
+        await expect(this.mock.$isValidSignatureNow(walletSigner, ethers.hashMessage(message), signature)).to.eventually
           .be.true;
       });
 
       it('with invalid signer', async function () {
         const walletSigner = ethers.zeroPadValue(this.mock.target, 20);
-        await expect(this.mock.$isValidSignatureNow(walletSigner, TEST_MESSAGE_HASH, this.eoaSignature)).to.eventually
+        const message = 'Hello, World!';
+        const signature = await this.signer.signMessage(message);
+        await expect(this.mock.$isValidSignatureNow(walletSigner, ethers.hashMessage(message), signature)).to.eventually
           .be.false;
       });
 
       it('with invalid signature', async function () {
         const walletSigner = ethers.zeroPadValue(this.wallet.target, 20);
-        await expect(this.mock.$isValidSignatureNow(walletSigner, WRONG_MESSAGE_HASH, this.eoaSignature)).to.eventually
+        const signature = await this.signer.signMessage('Hello, World!');
+        await expect(this.mock.$isValidSignatureNow(walletSigner, ethers.hashMessage('Nope'), signature)).to.eventually
           .be.false;
       });
     });
 
     describe('with ERC-7913 verifier', function () {
       it('with matching signer and signature', async function () {
-        await expect(this.mock.$isValidSignatureNow(this.validSignerBytes, TEST_MESSAGE_HASH, this.validSignature)).to
-          .eventually.be.true;
+        await expect(
+          this.mock.$isValidSignatureNow(
+            ethers.concat([this.verifier.target, VALID_SW_KEY_1]),
+            ethers.hashMessage('Hello, World!'),
+            VALID_SW_SIGNATURE_1,
+          ),
+        ).to.eventually.be.true;
       });
 
       it('with invalid verifier', async function () {
-        const invalidVerifierSigner = ethers.concat([this.mock.target, this.validKey]);
-        await expect(this.mock.$isValidSignatureNow(invalidVerifierSigner, TEST_MESSAGE_HASH, this.validSignature)).to
-          .eventually.be.false;
+        const invalidVerifierSigner = ethers.concat([this.mock.target, VALID_SW_KEY_1]);
+        await expect(
+          this.mock.$isValidSignatureNow(
+            invalidVerifierSigner,
+            ethers.hashMessage('Hello, World!'),
+            VALID_SW_SIGNATURE_1,
+          ),
+        ).to.eventually.be.false;
       });
 
       it('with invalid key', async function () {
-        await expect(this.mock.$isValidSignatureNow(this.invalidKeySignerBytes, TEST_MESSAGE_HASH, this.validSignature))
-          .to.eventually.be.false;
+        await expect(
+          this.mock.$isValidSignatureNow(
+            ethers.concat([this.verifier.target, ethers.randomBytes(32)]),
+            ethers.hashMessage('Hello, World!'),
+            VALID_SW_SIGNATURE_1,
+          ),
+        ).to.eventually.be.false;
       });
 
       it('with invalid signature', async function () {
-        await expect(this.mock.$isValidSignatureNow(this.validSignerBytes, TEST_MESSAGE_HASH, this.invalidSignature)).to
-          .eventually.be.false;
+        await expect(
+          this.mock.$isValidSignatureNow(
+            ethers.concat([this.verifier.target, VALID_SW_KEY_1]),
+            ethers.hashMessage('Hello, World!'),
+            ethers.randomBytes(65),
+          ),
+        ).to.eventually.be.false;
       });
 
       it('with signer too short', async function () {
         const shortSigner = ethers.randomBytes(19);
-        await expect(this.mock.$isValidSignatureNow(shortSigner, TEST_MESSAGE_HASH, this.validSignature)).to.eventually
-          .be.false;
+        await expect(
+          this.mock.$isValidSignatureNow(shortSigner, ethers.hashMessage('Hello, World!'), VALID_SW_SIGNATURE_1),
+        ).to.eventually.be.false;
       });
     });
   });
 
   describe('areValidNSignaturesNow', function () {
     it('should validate a single signature', async function () {
-      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, [this.eoaSigner], [this.eoaSignature])).to
-        .eventually.be.true;
+      const message = 'Hello, World!';
+      const signature = await this.signer.signMessage(message);
+      await expect(
+        this.mock.$areValidNSignaturesNow(
+          ethers.hashMessage(message),
+          [ethers.zeroPadValue(this.signer.address, 20)],
+          [signature],
+        ),
+      ).to.eventually.be.true;
     });
 
     it('should validate multiple signatures with different signer types', async function () {
-      // Order signers by ID (using keccak256)
-      const signers = [this.eoaSigner, this.walletSigner, this.validSignerBytes].sort(
-        (a, b) => ethers.keccak256(a) - ethers.keccak256(b),
-      );
-
-      // Create corresponding signatures in the same order
-      const signatures = signers.map(signer => {
-        if (ethers.dataLength(signer) === 20) {
-          // EOA or ERC-1271 wallet
-          if (ethers.getAddress(ethers.hexlify(signer)) === this.signer.address) {
-            return this.eoaSignature;
-          } else if (ethers.hexlify(signer) === ethers.hexlify(this.walletSigner)) {
-            return this.eoaSignature; // wallet uses signer's signature
-          }
-        } else {
-          // ERC-7913 verifier
-          return this.validSignature;
-        }
-        return ethers.randomBytes(65); // fallback, shouldn't be reached
-      });
-
-      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      const message = 'Hello, World!';
+      const signature = await this.signer.signMessage(message);
+      const pairs = [
+        [ethers.zeroPadValue(this.signer.address, 20), signature],
+        [ethers.zeroPadValue(this.wallet.target, 20), signature],
+        [ethers.concat([this.verifier.target, VALID_SW_KEY_1]), VALID_SW_SIGNATURE_1],
+      ].sort(([a], [b]) => ethers.keccak256(a) - ethers.keccak256(b));
+      const signers = pairs.map(([signer]) => signer);
+      const signatures = pairs.map(([, signature]) => signature);
+      await expect(this.mock.$areValidNSignaturesNow(ethers.hashMessage(message), signers, signatures)).to.eventually.be
+        .true;
     });
 
     it('should validate multiple EOA signatures', async function () {
-      // Sort by signer ID
-      const signers = [this.eoaSigner, this.eoaSigner2].sort((a, b) => ethers.keccak256(a) - ethers.keccak256(b));
-
-      // Map of signer to signature
-      const signatureMap = {
-        [ethers.hexlify(this.eoaSigner)]: this.eoaSignature,
-        [ethers.hexlify(this.eoaSigner2)]: this.eoaSignature2,
-      };
-
-      const signatures = signers.map(signer => signatureMap[ethers.hexlify(signer)]);
-
-      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      const message = 'Helllo, World!';
+      const pairs = [
+        [ethers.zeroPadValue(this.signer.address, 20), await this.signer.signMessage(message)],
+        [ethers.zeroPadValue(this.extraSigner.address, 20), await this.extraSigner.signMessage(message)],
+      ].sort(([a], [b]) => ethers.keccak256(a) - ethers.keccak256(b));
+      const signers = pairs.map(([signer]) => signer);
+      const signatures = pairs.map(([, signature]) => signature);
+      await expect(this.mock.$areValidNSignaturesNow(ethers.hashMessage(message), signers, signatures)).to.eventually.be
+        .true;
     });
 
     it('should validate multiple ERC-1271 wallet signatures', async function () {
-      // Sort by signer ID
-      const signers = [this.walletSigner, this.walletSigner2].sort((a, b) => ethers.keccak256(a) - ethers.keccak256(b));
-
-      // Both wallets use their respective owner's signatures
-      const signatures = [this.eoaSignature, this.eoaSignature2];
-      if (ethers.keccak256(this.walletSigner) - ethers.keccak256(this.walletSigner2) > 0) {
-        signatures.reverse();
-      }
-
-      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      const message = 'Helllo, World!';
+      const pairs = [
+        [ethers.zeroPadValue(this.wallet.target, 20), await this.signer.signMessage(message)],
+        [ethers.zeroPadValue(this.wallet2.target, 20), await this.extraSigner.signMessage(message)],
+      ].sort(([a], [b]) => ethers.keccak256(a) - ethers.keccak256(b));
+      const signers = pairs.map(([signer]) => signer);
+      const signatures = pairs.map(([, signature]) => signature);
+      await expect(this.mock.$areValidNSignaturesNow(ethers.hashMessage(message), signers, signatures)).to.eventually.be
+        .true;
     });
 
     it('should validate multiple ERC-7913 signatures', async function () {
-      // Sort by signer ID
-      const signers = [this.validSignerBytes, this.validSignerBytes2].sort(
-        (a, b) => ethers.keccak256(a) - ethers.keccak256(b),
-      );
-
-      // Map of signer to signature
-      const signatureMap = {
-        [ethers.hexlify(this.validSignerBytes)]: this.validSignature,
-        [ethers.hexlify(this.validSignerBytes2)]: this.validSignature2,
-      };
-
-      const signatures = signers.map(signer => signatureMap[ethers.hexlify(signer)]);
-
-      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+      const pairs = [
+        [ethers.concat([this.verifier.target, VALID_SW_KEY_1]), VALID_SW_SIGNATURE_1],
+        [ethers.concat([this.verifier.target, VALID_SW_KEY_2]), VALID_SW_SIGNATURE_2],
+      ].sort(([a], [b]) => ethers.keccak256(a) - ethers.keccak256(b));
+      const signers = pairs.map(([signer]) => signer);
+      const signatures = pairs.map(([, signature]) => signature);
+      await expect(this.mock.$areValidNSignaturesNow(ethers.hashMessage('Hello, World!'), signers, signatures)).to
+        .eventually.be.true;
     });
 
     it('should return false if any signature is invalid', async function () {
-      // Use two EOA signers but one signature is for the wrong message
+      const message = 'Hello, World!';
       await expect(
         this.mock.$areValidNSignaturesNow(
-          TEST_MESSAGE_HASH,
-          [this.eoaSigner, this.eoaSigner2],
-          [this.eoaSignature, this.wrongMessageSignature],
+          ethers.hashMessage(message),
+          [ethers.zeroPadValue(this.signer.address, 20), await this.extraSigner.signMessage(message)],
+          [await this.signer.signMessage(message), await this.signer.signMessage('Nope')],
         ),
       ).to.eventually.be.false;
     });
 
     it('should return false if signers are not ordered by ID', async function () {
-      // Ensure signers are ordered incorrectly
-      const signers = [this.eoaSigner, this.eoaSigner2];
-      const signatures = [this.eoaSignature, this.eoaSignature2];
+      const message = 'Hello, World!';
+      const pairs = [
+        [ethers.zeroPadValue(this.signer.address, 20), await this.signer.signMessage(message)],
+        [ethers.zeroPadValue(this.extraSigner.address, 20), await this.extraSigner.signMessage(message)],
+      ];
 
-      // If they're already ordered, swap them
-      if (ethers.keccak256(signers[0]) - ethers.keccak256(signers[1])) {
-        signers.reverse();
-        signatures.reverse();
+      if (ethers.keccak256(pairs[0][0]) - ethers.keccak256(pairs[1][0])) {
+        pairs.reverse();
       }
 
-      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.false;
+      const signers = pairs.map(([signer]) => signer);
+      const signatures = pairs.map(([, signature]) => signature);
+      await expect(this.mock.$areValidNSignaturesNow(ethers.hashMessage(message), signers, signatures)).to.eventually.be
+        .false;
     });
 
     it('should return false if there are duplicate signers', async function () {
+      const message = 'Hello, World!';
       await expect(
         this.mock.$areValidNSignaturesNow(
-          TEST_MESSAGE_HASH,
-          [this.eoaSigner, this.eoaSigner], // Same signer used twice
-          [this.eoaSignature, this.eoaSignature],
+          ethers.hashMessage(message),
+          [ethers.zeroPadValue(this.signer.address, 20), ethers.zeroPadValue(this.signer.address, 20)], // Same signer used twice
+          [await this.signer.signMessage(message), await this.signer.signMessage(message)],
         ),
       ).to.eventually.be.false;
     });
 
     it('should fail if signatures array length does not match signers array length', async function () {
+      const message = 'Hello, World!';
       await expect(
         this.mock.$areValidNSignaturesNow(
-          TEST_MESSAGE_HASH,
-          [this.eoaSigner, this.eoaSigner2],
-          [this.eoaSignature], // Missing one signature
+          ethers.hashMessage(message),
+          [ethers.zeroPadValue(this.signer.address, 20), await this.extraSigner.signMessage(message)],
+          [await this.signer.signMessage(message)], // Missing one signature
         ),
       ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
     });
 
     it('should pass with empty arrays', async function () {
-      await expect(this.mock.$areValidNSignaturesNow(TEST_MESSAGE_HASH, [], [])).to.eventually.be.true;
+      await expect(this.mock.$areValidNSignaturesNow(ethers.hashMessage('Hello, World!'), [], [])).to.eventually.be
+        .true;
     });
   });
 });

--- a/test/utils/cryptography/ERC7913Utils.test.js
+++ b/test/utils/cryptography/ERC7913Utils.test.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
 
 const TEST_MESSAGE = ethers.id('OpenZeppelin');
 const TEST_MESSAGE_HASH = ethers.hashMessage(TEST_MESSAGE);
@@ -9,43 +10,70 @@ const WRONG_MESSAGE = ethers.id('Nope');
 const WRONG_MESSAGE_HASH = ethers.hashMessage(WRONG_MESSAGE);
 
 async function fixture() {
-  const [, signer, other] = await ethers.getSigners();
+  const [, signer, other, extraSigner] = await ethers.getSigners();
   const mock = await ethers.deployContract('$ERC7913Utils');
 
   // Deploy a mock ERC-1271 wallet
   const wallet = await ethers.deployContract('ERC1271WalletMock', [signer]);
+  const wallet2 = await ethers.deployContract('ERC1271WalletMock', [extraSigner]);
 
   // Deploy a mock ERC-7913 verifier
   const verifier = await ethers.deployContract('ERC7913VerifierMock');
 
   // Create test keys
-  const validKey = ethers.toUtf8Bytes('valid_key');
+  const validKey = ethers.toUtf8Bytes('valid_key_1');
+  const validKey2 = ethers.toUtf8Bytes('valid_key_2');
   const invalidKey = ethers.randomBytes(32);
 
   // Create signer bytes (verifier address + key)
   const validSignerBytes = ethers.concat([verifier.target, validKey]);
+  const validSignerBytes2 = ethers.concat([verifier.target, validKey2]);
   const invalidKeySignerBytes = ethers.concat([verifier.target, invalidKey]);
 
   // Create test signatures
-  const validSignature = ethers.toUtf8Bytes('valid_signature');
+  const validSignature = ethers.toUtf8Bytes('valid_signature_1');
+  const validSignature2 = ethers.toUtf8Bytes('valid_signature_2');
   const invalidSignature = ethers.randomBytes(65);
 
-  // Get EOA signature from the signer
+  // Get EOA signatures from the signers
   const eoaSignature = await signer.signMessage(TEST_MESSAGE);
+  const eoaSignature2 = await extraSigner.signMessage(TEST_MESSAGE);
+  const wrongMessageSignature = await signer.signMessage(WRONG_MESSAGE);
+
+  // Create EOA signers
+  const eoaSigner = ethers.zeroPadValue(signer.address, 20);
+  const eoaSigner2 = ethers.zeroPadValue(extraSigner.address, 20);
+  const wrongSigner = ethers.zeroPadValue(other.address, 20);
+
+  // Create Wallet signers
+  const walletSigner = ethers.zeroPadValue(wallet.target, 20);
+  const walletSigner2 = ethers.zeroPadValue(wallet2.target, 20);
 
   return {
     signer,
     other,
+    extraSigner,
     mock,
     wallet,
+    wallet2,
     verifier,
     validKey,
+    validKey2,
     invalidKey,
     validSignerBytes,
+    validSignerBytes2,
     invalidKeySignerBytes,
     validSignature,
+    validSignature2,
     invalidSignature,
     eoaSignature,
+    eoaSignature2,
+    wrongMessageSignature,
+    eoaSigner,
+    eoaSigner2,
+    wrongSigner,
+    walletSigner,
+    walletSigner2,
   };
 }
 
@@ -122,6 +150,132 @@ describe('ERC7913Utils', function () {
         await expect(this.mock.$isValidSignatureNow(shortSigner, TEST_MESSAGE_HASH, this.validSignature)).to.eventually
           .be.false;
       });
+    });
+  });
+
+  describe('isValidNSignaturesNow', function () {
+    it('should validate a single signature', async function () {
+      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, [this.eoaSigner], [this.eoaSignature])).to
+        .eventually.be.true;
+    });
+
+    it('should validate multiple signatures with different signer types', async function () {
+      // Order signers by ID (using keccak256)
+      const signers = [this.eoaSigner, this.walletSigner, this.validSignerBytes].sort(
+        (a, b) => ethers.keccak256(a) - ethers.keccak256(b),
+      );
+
+      // Create corresponding signatures in the same order
+      const signatures = signers.map(signer => {
+        if (ethers.dataLength(signer) === 20) {
+          // EOA or ERC-1271 wallet
+          if (ethers.getAddress(ethers.hexlify(signer)) === this.signer.address) {
+            return this.eoaSignature;
+          } else if (ethers.hexlify(signer) === ethers.hexlify(this.walletSigner)) {
+            return this.eoaSignature; // wallet uses signer's signature
+          }
+        } else {
+          // ERC-7913 verifier
+          return this.validSignature;
+        }
+        return ethers.randomBytes(65); // fallback, shouldn't be reached
+      });
+
+      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+    });
+
+    it('should validate multiple EOA signatures', async function () {
+      // Sort by signer ID
+      const signers = [this.eoaSigner, this.eoaSigner2].sort((a, b) => ethers.keccak256(a) - ethers.keccak256(b));
+
+      // Map of signer to signature
+      const signatureMap = {
+        [ethers.hexlify(this.eoaSigner)]: this.eoaSignature,
+        [ethers.hexlify(this.eoaSigner2)]: this.eoaSignature2,
+      };
+
+      const signatures = signers.map(signer => signatureMap[ethers.hexlify(signer)]);
+
+      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+    });
+
+    it('should validate multiple ERC-1271 wallet signatures', async function () {
+      // Sort by signer ID
+      const signers = [this.walletSigner, this.walletSigner2].sort((a, b) => ethers.keccak256(a) - ethers.keccak256(b));
+
+      // Both wallets use their respective owner's signatures
+      const signatures = [this.eoaSignature, this.eoaSignature2];
+      if (ethers.keccak256(this.walletSigner) - ethers.keccak256(this.walletSigner2) > 0) {
+        signatures.reverse();
+      }
+
+      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+    });
+
+    it('should validate multiple ERC-7913 signatures', async function () {
+      // Sort by signer ID
+      const signers = [this.validSignerBytes, this.validSignerBytes2].sort(
+        (a, b) => ethers.keccak256(a) - ethers.keccak256(b),
+      );
+
+      // Map of signer to signature
+      const signatureMap = {
+        [ethers.hexlify(this.validSignerBytes)]: this.validSignature,
+        [ethers.hexlify(this.validSignerBytes2)]: this.validSignature2,
+      };
+
+      const signatures = signers.map(signer => signatureMap[ethers.hexlify(signer)]);
+
+      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.true;
+    });
+
+    it('should return false if any signature is invalid', async function () {
+      // Use two EOA signers but one signature is for the wrong message
+      await expect(
+        this.mock.$isValidNSignaturesNow(
+          TEST_MESSAGE_HASH,
+          [this.eoaSigner, this.eoaSigner2],
+          [this.eoaSignature, this.wrongMessageSignature],
+        ),
+      ).to.eventually.be.false;
+    });
+
+    it('should return false if signers are not ordered by ID', async function () {
+      // Ensure signers are ordered incorrectly
+      const signers = [this.eoaSigner, this.eoaSigner2];
+      const signatures = [this.eoaSignature, this.eoaSignature2];
+
+      // If they're already ordered, swap them
+      if (ethers.keccak256(signers[0]) - ethers.keccak256(signers[1])) {
+        signers.reverse();
+        signatures.reverse();
+      }
+
+      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, signers, signatures)).to.eventually.be.false;
+    });
+
+    it('should return false if there are duplicate signers', async function () {
+      await expect(
+        this.mock.$isValidNSignaturesNow(
+          TEST_MESSAGE_HASH,
+          [this.eoaSigner, this.eoaSigner], // Same signer used twice
+          [this.eoaSignature, this.eoaSignature],
+        ),
+      ).to.eventually.be.false;
+    });
+
+    it('should fail if signatures array length does not match signers array length', async function () {
+      await expect(
+        this.mock.$isValidNSignaturesNow(
+          TEST_MESSAGE_HASH,
+          [this.eoaSigner, this.eoaSigner2],
+          [this.eoaSignature], // Missing one signature
+        ),
+      ).to.be.revertedWithPanic(PANIC_CODES.ARRAY_ACCESS_OUT_OF_BOUNDS);
+    });
+
+    it('should pass with empty arrays', async function () {
+      await expect(this.mock.$isValidNSignaturesNow(TEST_MESSAGE_HASH, [], [])).to.eventually.be.true;
     });
   });
 });


### PR DESCRIPTION
Allows to reuse the logic for verifying multiple signatures using ERC-7913. It'll be repeated across a couple of contracts