### PR TITLE
Fix typo in README and format test description

### DIFF
--- a/contracts/token/README.adoc
+++ b/contracts/token/README.adoc
@@ -3,7 +3,7 @@
 [.readme-notice]
 NOTE: This document is better viewed at https://docs.openzeppelin.com/community-contracts/token
 
-Set of extensions and utilities for tokens (e.g ERC-20, ERC-721, ERC-1155) and derivated ERCs (e.g. ERC-4626, ERC-1363).
+Set of extensions and utilities for tokens (e.g ERC-20, ERC-721, ERC-1155) and derived ERCs (e.g. ERC-4626, ERC-1363).
 
  * {OnTokenTransferAdapter}: Adapter of the ERC-1363 receiver interface to comply with Chainlink's 667 interface.
  * {ERC20Allowlist}: Extension of ERC20 with transfers and approvals that require users to be registered into an allowlist.

--- a/test/access/manager/AccessManagerLight.test.js
+++ b/test/access/manager/AccessManagerLight.test.js
@@ -71,7 +71,7 @@ describe('AccessManaged', function () {
         });
       });
 
-      describe('complexe case: one of many groups', async function () {
+      describe('complex case: one of many groups', async function () {
         it('some intersection', async function () {
           this.userGroups = [32, 42, 94, 128]; // User has all these groups
           this.targetGroups = [17, 35, 42, 69, 91]; // Target accepts any of these groups


### PR DESCRIPTION


**Description:**
This PR includes the following changes:

1. Fixed a typo in contracts/token/README.adoc:
   - Changed "derivated" to "derived" in the token extensions description

2. Minor formatting fix in test/access/manager/AccessManagerLight.test.js:
   - Adjusted spacing in test case description

The changes are minor text corrections that improve documentation clarity and test readability without affecting functionality.
