### PR TITLE
Add ERC7579 validators to API Reference

### DIFF
--- a/contracts/account/README.adoc
+++ b/contracts/account/README.adoc
@@ -8,6 +8,8 @@ This directory includes contracts to build accounts for ERC-4337. These include:
  * {AccountERC7579}: An extension of `Account` that implements support for ERC-7579 modules.
  * {AccountERC7579Hooked}: An extension of `AccountERC7579` with support for a single hook module (type 4).
  * {ERC7821}: Minimal batch executor implementation contracts. Useful to enable easy batch execution for smart contracts.
+ * {ERC7579Validator}: Abstract validator module for ERC-7579 accounts that provides base implementation for signature validation.
+ * {ERC7579SignatureValidator}: Implementation of ERC7579Validator using ERC-7913 signature verification for address-less cryptographic keys.
  * {PaymasterCore}: An ERC-4337 paymaster implementation that includes the core logic to validate and pay for user operations.
  * {PaymasterERC20}: A paymaster that allows users to pay for user operations using ERC-20 tokens.
  * {PaymasterERC721Owner}: A paymaster that allows users to pay for user operations based on ERC-721 ownership.
@@ -24,6 +26,14 @@ This directory includes contracts to build accounts for ERC-4337. These include:
 {{AccountERC7579Hooked}}
 
 {{ERC7821}}
+
+== Modules
+
+=== Validators
+
+{{ERC7579Validator}}
+
+{{ERC7579SignatureValidator}}
 
 == Paymaster
 

--- a/contracts/account/modules/ERC7579SignatureValidator.sol
+++ b/contracts/account/modules/ERC7579SignatureValidator.sol
@@ -17,8 +17,9 @@ import {IERC7579Module} from "@openzeppelin/contracts/interfaces/draft-IERC7579.
  * Ethereum address.
  *
  * The validator implements two key functions from ERC-7579:
- * - `validateUserOp`: Validates ERC-4337 user operations using ERC-7913 signatures
- * - `isValidSignatureWithSender`: Implements ERC-1271 signature verification via ERC-7913
+ *
+ * * `validateUserOp`: Validates ERC-4337 user operations using ERC-7913 signatures
+ * * `isValidSignatureWithSender`: Implements ERC-1271 signature verification via ERC-7913
  *
  * Example usage with an account:
  *


### PR DESCRIPTION
A guide on how to use ERC-7579 modules will come up later