### PR TITLE
Rename ERC7913 verifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## 12-04-2025
 
 - `SignerERC7913`: Abstract signer that verifies signatures using the ERC-7913 workflow.
-- `ERC7913SignatureVerifierP256` and `ERC7913SignatureVerifierRSA`: Ready to use ERC-7913 verifiers that implement key verification for P256 (secp256r1) and RSA keys.
+- `ERC7913P256Verifier` and `ERC7913RSAVerifier`: Ready to use ERC-7913 verifiers that implement key verification for P256 (secp256r1) and RSA keys.
 - `ERC7913Utils`: Utilities library for verifying signatures by ERC-7913 formatted signers.
 
 ## 11-04-2025

--- a/contracts/utils/README.adoc
+++ b/contracts/utils/README.adoc
@@ -12,7 +12,7 @@ Miscellaneous contracts and libraries containing utility functions you can use t
  * {SignerECDSA}, {SignerP256}, {SignerRSA}: Implementations of an {AbstractSigner} with specific signature validation algorithms.
  * {SignerERC7702}: Implementation of {AbstractSigner} that validates signatures using the contract's own address as the signer, useful for delegated accounts following EIP-7702.
  * {SignerERC7913}, {MultiSignerERC7913}, {MultiSignerERC7913Weighted}: Implementations of {AbstractSigner} that validate signatures based on ERC-7913. Including a simple and weighted multisignature scheme.
- * {ERC7913SignatureVerifierP256}, {ERC7913SignatureVerifierRSA}: Ready to use ERC-7913 signature verifiers for P256 and RSA keys
+ * {ERC7913P256Verifier}, {ERC7913RSAVerifier}: Ready to use ERC-7913 signature verifiers for P256 and RSA keys
  * {SignerZKEmail}: Implementation of an {AbstractSigner} that enables email-based authentication through zero-knowledge proofs.
  * {ZKEmailUtils}: Library for ZKEmail signature validation utilities, enabling email-based authentication through zero-knowledge proofs.
  * {EnumerableSetExtended} and {EnumerableMapExtended}: Extensions of the `EnumerableSet` and `EnumerableMap` libraries with more types, including non-value types.
@@ -50,9 +50,9 @@ Miscellaneous contracts and libraries containing utility functions you can use t
 
 {{ERC7913Utils}}
 
-{{ERC7913SignatureVerifierP256}}
+{{ERC7913P256Verifier}}
 
-{{ERC7913SignatureVerifierRSA}}
+{{ERC7913RSAVerifier}}
 
 == Structs
 

--- a/contracts/utils/cryptography/ERC7913P256Verifier.sol
+++ b/contracts/utils/cryptography/ERC7913P256Verifier.sol
@@ -8,7 +8,7 @@ import {IERC7913SignatureVerifier} from "../../interfaces/IERC7913.sol";
 /**
  * @dev ERC-7913 signature verifier that support P256 (secp256r1) keys.
  */
-contract ERC7913SignatureVerifierP256 is IERC7913SignatureVerifier {
+contract ERC7913P256Verifier is IERC7913SignatureVerifier {
     /// @inheritdoc IERC7913SignatureVerifier
     function verify(bytes calldata key, bytes32 hash, bytes calldata signature) public view virtual returns (bytes4) {
         // Signature length may be 0x40 or 0x41.

--- a/contracts/utils/cryptography/ERC7913RSAVerifier.sol
+++ b/contracts/utils/cryptography/ERC7913RSAVerifier.sol
@@ -8,7 +8,7 @@ import {IERC7913SignatureVerifier} from "../../interfaces/IERC7913.sol";
 /**
  * @dev ERC-7913 signature verifier that support RSA keys.
  */
-contract ERC7913SignatureVerifierRSA is IERC7913SignatureVerifier {
+contract ERC7913RSAVerifier is IERC7913SignatureVerifier {
     /// @inheritdoc IERC7913SignatureVerifier
     function verify(bytes calldata key, bytes32 hash, bytes calldata signature) public view virtual returns (bytes4) {
         (bytes memory e, bytes memory n) = abi.decode(key, (bytes, bytes));

--- a/contracts/utils/cryptography/ERC7913ZKEmailVerifier.sol
+++ b/contracts/utils/cryptography/ERC7913ZKEmailVerifier.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.24;
 
 import {IDKIMRegistry} from "@zk-email/contracts/DKIMRegistry.sol";
-import {IVerifier} from "@zk-email/email-tx-builder/interfaces/IVerifier.sol";
-import {EmailAuthMsg} from "@zk-email/email-tx-builder/interfaces/IEmailTypes.sol";
+import {IVerifier} from "@zk-email/email-tx-builder/src/interfaces/IVerifier.sol";
+import {EmailAuthMsg} from "@zk-email/email-tx-builder/src/interfaces/IEmailTypes.sol";
 import {IERC7913SignatureVerifier} from "../../interfaces/IERC7913.sol";
 import {ZKEmailUtils} from "./ZKEmailUtils.sol";
 

--- a/contracts/utils/cryptography/ERC7913ZKEmailVerifier.sol
+++ b/contracts/utils/cryptography/ERC7913ZKEmailVerifier.sol
@@ -35,7 +35,7 @@ import {ZKEmailUtils} from "./ZKEmailUtils.sol";
  *   }
  * ```
  */
-abstract contract ERC7913SignatureVerifierZKEmail is IERC7913SignatureVerifier {
+abstract contract ERC7913ZKEmailVerifier is IERC7913SignatureVerifier {
     using ZKEmailUtils for EmailAuthMsg;
 
     /**

--- a/test/account/AccountERC7913.test.js
+++ b/test/account/AccountERC7913.test.js
@@ -42,9 +42,9 @@ async function fixture() {
   const zkEmailVerifier = await ethers.deployContract('ZKEmailVerifierMock');
 
   // ERC-7913 verifiers
-  const verifierP256 = await ethers.deployContract('ERC7913SignatureVerifierP256');
-  const verifierRSA = await ethers.deployContract('ERC7913SignatureVerifierRSA');
-  const verifierZKEmail = await ethers.deployContract('$ERC7913SignatureVerifierZKEmail');
+  const verifierP256 = await ethers.deployContract('ERC7913P256Verifier');
+  const verifierRSA = await ethers.deployContract('ERC7913RSAVerifier');
+  const verifierZKEmail = await ethers.deployContract('$ERC7913ZKEmailVerifier');
 
   // ERC-4337 env
   const helper = new ERC4337Helper();

--- a/test/account/AccountMultiSigner.test.js
+++ b/test/account/AccountMultiSigner.test.js
@@ -26,8 +26,8 @@ async function fixture() {
   const target = await ethers.deployContract('CallReceiverMockExtended');
 
   // ERC-7913 verifiers
-  const verifierP256 = await ethers.deployContract('ERC7913SignatureVerifierP256');
-  const verifierRSA = await ethers.deployContract('ERC7913SignatureVerifierRSA');
+  const verifierP256 = await ethers.deployContract('ERC7913P256Verifier');
+  const verifierRSA = await ethers.deployContract('ERC7913RSAVerifier');
 
   // ERC-4337 env
   const helper = new ERC4337Helper();

--- a/test/account/AccountMultiSignerWeighted.test.js
+++ b/test/account/AccountMultiSignerWeighted.test.js
@@ -26,8 +26,8 @@ async function fixture() {
   const target = await ethers.deployContract('CallReceiverMockExtended');
 
   // ERC-7913 verifiers
-  const verifierP256 = await ethers.deployContract('ERC7913SignatureVerifierP256');
-  const verifierRSA = await ethers.deployContract('ERC7913SignatureVerifierRSA');
+  const verifierP256 = await ethers.deployContract('ERC7913P256Verifier');
+  const verifierRSA = await ethers.deployContract('ERC7913RSAVerifier');
 
   // ERC-4337 env
   const helper = new ERC4337Helper();

--- a/test/account/extensions/AccountERC7579.test.js
+++ b/test/account/extensions/AccountERC7579.test.js
@@ -25,8 +25,8 @@ async function fixture() {
   const erc7579Validator = await ethers.deployContract('$ERC7579SignatureValidator');
 
   // ERC-7913 verifiers
-  const verifierP256 = await ethers.deployContract('ERC7913SignatureVerifierP256');
-  const verifierRSA = await ethers.deployContract('ERC7913SignatureVerifierRSA');
+  const verifierP256 = await ethers.deployContract('ERC7913P256Verifier');
+  const verifierRSA = await ethers.deployContract('ERC7913RSAVerifier');
 
   // ERC-4337 env
   const helper = new ERC4337Helper();

--- a/test/account/modules/ERC7579SignatureValidator.test.js
+++ b/test/account/modules/ERC7579SignatureValidator.test.js
@@ -22,8 +22,8 @@ async function fixture() {
   const mock = await ethers.deployContract('$ERC7579SignatureValidator');
 
   // ERC-7913 verifiers
-  const verifierP256 = await ethers.deployContract('ERC7913SignatureVerifierP256');
-  const verifierRSA = await ethers.deployContract('ERC7913SignatureVerifierRSA');
+  const verifierP256 = await ethers.deployContract('ERC7913P256Verifier');
+  const verifierRSA = await ethers.deployContract('ERC7913RSAVerifier');
 
   // ERC-4337 env
   const helper = new ERC4337Helper();


### PR DESCRIPTION
ERC7913SignatureVerifier takes too much space and being a signature verifier is already implicit by "ERC7913". Also, I put the algorithm before "Verifier" since that's the most relevant think developers are looking for.

Also, note that the current name gets cropped in the docs