### PR TITLE
Treat subsequent onInstall calls as no-ops in ERC7579SignatureValidator

### DIFF
--- a/contracts/account/modules/ERC7579SignatureValidator.sol
+++ b/contracts/account/modules/ERC7579SignatureValidator.sol
@@ -58,9 +58,6 @@ contract ERC7579SignatureValidator is ERC7579Validator {
     /// @dev Thrown when the signer length is less than 20 bytes.
     error ERC7579SignatureValidatorInvalidSignerLength();
 
-    /// @dev Thrown when the module is already installed.
-    error ERC7579SignatureValidatorAlreadyInstalled();
-
     /// @dev Return the ERC-7913 signer (i.e. `verifier || key`).
     function signer(address account) public view virtual returns (bytes memory) {
         return _signers[account];
@@ -70,12 +67,13 @@ contract ERC7579SignatureValidator is ERC7579Validator {
      * @dev See {IERC7579Module-onInstall}.
      * Reverts with {ERC7579SignatureValidatorAlreadyInstalled} if the module is already installed.
      *
-     * IMPORTANT: An account can only call onInstall once. If called directly by the account,
-     * the signer will be set to the provided data. Future installations will revert.
+     * NOTE: An account can only call onInstall once. If called directly by the account,
+     * the signer will be set to the provided data. Future installations will behave as a no-op.
      */
     function onInstall(bytes calldata data) public virtual {
-        require(signer(msg.sender).length == 0, ERC7579SignatureValidatorAlreadyInstalled());
-        setSigner(data);
+        if (signer(msg.sender).length == 0) {
+            setSigner(data);
+        }
     }
 
     /**

--- a/test/account/modules/ERC7579SignatureValidator.test.js
+++ b/test/account/modules/ERC7579SignatureValidator.test.js
@@ -71,11 +71,9 @@ describe('ERC7579SignatureValidator', function () {
     const signerData = ethers.solidityPacked(['address'], [signerECDSA.address]);
     await expect(this.mockFromAccount.onInstall(signerData)).to.not.be.reverted;
 
-    // Second installation should fail
-    await expect(this.mockFromAccount.onInstall(signerData)).to.be.revertedWithCustomError(
-      this.mock,
-      'ERC7579SignatureValidatorAlreadyInstalled',
-    );
+    // Second installation should behave as a no-op
+    await this.mockFromAccount.onInstall(ethers.solidityPacked(['address'], [ethers.Wallet.createRandom().address])); // Not revert
+    await expect(this.mock.signer(this.mockAccount.address)).to.eventually.equal(signerData); // No change in signers
   });
 
   it('emits event on ERC7579SignatureValidatorSignerSet on both installation and uninstallation', async function () {


### PR DESCRIPTION
As a general oz rule, we treat operations as a no-op when possible, and I came to the conclusion that it's better if `onInstall` functions are noops when appropriate, which makes it easier to extend