### PR TITLE
Vendor dependencies in `vendored` branch

### DIFF
--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -16,7 +16,8 @@ jobs:
         uses: ./.github/actions/setup
       - run: bash scripts/git-user-config.sh
       - name: Vendor dependencies
-        run: npm run lint vendored
       - run: |
+          npm run vendored
+          git checkout vendored
           git commit -m "Vendor $(git rev-parse --short HEAD)"
-          git push origin vendored
+          git push --all origin

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ./.github/actions/setup
       - run: bash scripts/git-user-config.sh
       - name: Vendor dependencies
-      - run: |
+        run: |
           npm run vendored
           git checkout vendored
           git commit -m "Vendor $(git rev-parse --short HEAD)"

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -1,0 +1,22 @@
+name: vendor dependencies
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  vendor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - run: bash scripts/git-user-config.sh
+      - name: Vendor dependencies
+        run: npm run lint vendored
+      - run: |
+          git commit -m "Vendor $(git rev-parse --short HEAD)"
+          git push origin vendored

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Vendor dependencies
         run: |
           npm run vendored
-          git checkout vendored
+          git checkout -f vendored
           git commit -m "Vendor $(git rev-parse --short HEAD)"
           git push --all origin

--- a/hardhat/remappings.js
+++ b/hardhat/remappings.js
@@ -26,7 +26,7 @@ task(UPDATED_VENDORED_REMAPPINGS).setAction(() => {
   }
 
   const vendoredRemappings = Object.entries(remappings)
-    .map(r => [r[0], r[1].replace(NODE_MODULES_PATH, 'lib/')])
+    .map(r => [r[0], r[1].replace(NODE_MODULES_PATH, LIB_PATH)])
     .map(r => `${r[0]}=${r[1]}`)
     .join('\n');
 

--- a/hardhat/remappings.js
+++ b/hardhat/remappings.js
@@ -23,7 +23,7 @@ task(UPDATED_VENDORED_REMAPPINGS).setAction(() => {
 
   for (const [, src] of Object.entries(remappings).filter(r => r[1].includes(NODE_MODULES_PATH))) {
     const dir = src.replace(NODE_MODULES_PATH, LIB_PATH);
-    fs.rmSync(dir, { recursive: true });
+    fs.rmSync(dir, { recursive: true, force: true });
     fs.cpSync(src, dir, { recursive: true });
   }
 

--- a/hardhat/remappings.js
+++ b/hardhat/remappings.js
@@ -22,7 +22,9 @@ task(UPDATED_VENDORED_REMAPPINGS).setAction(() => {
   const LIB_PATH = 'lib/';
 
   for (const [, src] of Object.entries(remappings).filter(r => r[1].includes(NODE_MODULES_PATH))) {
-    fs.cpSync(src, src.replace(NODE_MODULES_PATH, LIB_PATH), { recursive: true });
+    const dir = src.replace(NODE_MODULES_PATH, LIB_PATH);
+    fs.rmSync(dir, { recursive: true });
+    fs.cpSync(src, dir, { recursive: true });
   }
 
   const vendoredRemappings = Object.entries(remappings)

--- a/hardhat/remappings.js
+++ b/hardhat/remappings.js
@@ -2,18 +2,33 @@ const fs = require('fs');
 const { task } = require('hardhat/config');
 const { TASK_COMPILE_GET_REMAPPINGS } = require('hardhat/builtin-tasks/task-names');
 
-task(TASK_COMPILE_GET_REMAPPINGS).setAction((taskArgs, env, runSuper) =>
-  runSuper().then(remappings =>
-    Object.assign(
-      remappings,
-      Object.fromEntries(
-        fs
-          .readFileSync('remappings.txt', 'utf-8')
-          .split('\n')
-          .filter(Boolean)
-          .filter(line => !line.startsWith('#'))
-          .map(line => line.trim().split('=')),
-      ),
-    ),
-  ),
+const UPDATED_VENDORED_REMAPPINGS = 'vendor';
+
+const remappings = Object.fromEntries(
+  fs
+    .readFileSync('remappings.txt', 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .filter(line => !line.startsWith('#'))
+    .map(line => line.trim().split('=')),
 );
+
+task(TASK_COMPILE_GET_REMAPPINGS).setAction((taskArgs, env, runSuper) =>
+  runSuper().then(r => Object.assign(r, remappings)),
+);
+
+task(UPDATED_VENDORED_REMAPPINGS).setAction(() => {
+  const NODE_MODULES_PATH = 'node_modules/';
+  const LIB_PATH = 'lib/';
+
+  for (const [, src] of Object.entries(remappings).filter(r => r[1].includes(NODE_MODULES_PATH))) {
+    fs.cpSync(src, src.replace(NODE_MODULES_PATH, LIB_PATH), { recursive: true });
+  }
+
+  const vendoredRemappings = Object.entries(remappings)
+    .map(r => [r[0], r[1].replace(NODE_MODULES_PATH, 'lib/')])
+    .map(r => `${r[0]}=${r[1]}`)
+    .join('\n');
+
+  fs.writeFileSync('remappings.txt', vendoredRemappings);
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "scripts": {
     "compile": "hardhat compile",
+    "vendor": "hardhat vendor",
     "clean": "hardhat clean && rimraf build contracts/build",
     "docs": "npm run prepare-docs && oz-docs",
     "docs:watch": "oz-docs watch contracts docs/templates docs/config.js",


### PR DESCRIPTION
Teams installing the repository in Foundry would need to install dependencies regardless. With this proposal, the idea is that they just point to a different branch where the dependencies are vendored to `lib/`