### PR TITLE
Decode WebAuthn object from calldata buffers, with out-of-bound detection

### DIFF
--- a/contracts/utils/cryptography/WebAuthn.sol
+++ b/contracts/utils/cryptography/WebAuthn.sol
@@ -247,7 +247,6 @@ library WebAuthn {
      */
     function tryDecodeAuth(bytes calldata input) internal pure returns (bool success, WebAuthnAuth calldata auth) {
         // Default result (optimistic)
-        success = true;
         assembly ("memory-safe") {
             auth := input.offset
         }
@@ -274,5 +273,7 @@ library WebAuthn {
             input.length - authenticatorDataOffset - 0x20 < authenticatorDataLength ||
             input.length - clientDataJSONOffset - 0x20 < clientDataJSONLength
         ) return (false, auth);
+
+        return (true, auth);
     }
 }

--- a/contracts/utils/cryptography/WebAuthn.sol
+++ b/contracts/utils/cryptography/WebAuthn.sol
@@ -248,6 +248,13 @@ library WebAuthn {
         return Strings.equal(string(actualChallengeBytes), string(expectedChallengeBytes));
     }
 
+    /**
+     * @dev Verifies that calldata bytes (`input`) represents a valid `WebAuthnAuth` object. If encoding is valid,
+     * returns true and the calldata view at the object. Otherwise, returns false and an invalid calldata object.
+     *
+     * NOTE: The returned `auth` object should not be accessed if `success` is false. Trying to access the data may
+     * cause revert/panic.
+     */
     function tryDecodeAuth(bytes calldata input) internal pure returns (bool success, WebAuthnAuth calldata auth) {
         // Default result (optimistic)
         success = true;

--- a/contracts/utils/cryptography/WebAuthn.sol
+++ b/contracts/utils/cryptography/WebAuthn.sol
@@ -246,7 +246,6 @@ library WebAuthn {
      * cause revert/panic.
      */
     function tryDecodeAuth(bytes calldata input) internal pure returns (bool success, WebAuthnAuth calldata auth) {
-        // Default result (optimistic)
         assembly ("memory-safe") {
             auth := input.offset
         }

--- a/test/helpers/signers.js
+++ b/test/helpers/signers.js
@@ -92,16 +92,14 @@ class WebAuthnSigningKey extends P256SigningKey {
     const { r, s } = super.sign(sha256(concat([authenticatorData, sha256(toUtf8Bytes(clientDataJSON))])));
 
     const serialized = AbiCoder.defaultAbiCoder().encode(
-      ['tuple(bytes32,bytes32,uint256,uint256,bytes,string)'],
+      ['bytes32', 'bytes32', 'uint256', 'uint256', 'bytes', 'string'],
       [
-        [
-          r,
-          s,
-          clientDataJSON.indexOf('"challenge"'),
-          clientDataJSON.indexOf('"type"'),
-          authenticatorData,
-          clientDataJSON,
-        ],
+        r,
+        s,
+        clientDataJSON.indexOf('"challenge"'),
+        clientDataJSON.indexOf('"type"'),
+        authenticatorData,
+        clientDataJSON,
       ],
     );
 


### PR DESCRIPTION
Inspired by https://github.com/OpenZeppelin/openzeppelin-contracts/pull/5400
and https://github.com/Vectorized/solady/blob/main/src/utils/WebAuthn.sol#L180-L211