### PR TITLE
Refactor WebAuthn

### DIFF
--- a/contracts/utils/cryptography/signers/SignerWebAuthn.sol
+++ b/contracts/utils/cryptography/signers/SignerWebAuthn.sol
@@ -44,7 +44,7 @@ abstract contract SignerWebAuthn is SignerP256 {
 
         return
             decodeSuccess
-                ? WebAuthn.verifyMinimal(abi.encodePacked(hash), auth, qx, qy)
+                ? WebAuthn.verify(abi.encodePacked(hash), auth, qx, qy)
                 : super._rawSignatureValidation(hash, signature);
     }
 }

--- a/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913WebAuthnVerifier.sol
@@ -25,7 +25,7 @@ contract ERC7913WebAuthnVerifier is IERC7913SignatureVerifier {
         return
             decodeSuccess &&
                 key.length == 0x40 &&
-                WebAuthn.verifyMinimal(abi.encodePacked(hash), auth, bytes32(key[0x00:0x20]), bytes32(key[0x20:0x40]))
+                WebAuthn.verify(abi.encodePacked(hash), auth, bytes32(key[0x00:0x20]), bytes32(key[0x20:0x40]))
                 ? IERC7913SignatureVerifier.verify.selector
                 : bytes4(0xFFFFFFFF);
     }

--- a/test/helpers/signers.js
+++ b/test/helpers/signers.js
@@ -1,11 +1,12 @@
 const { P256SigningKey } = require('@openzeppelin/contracts/test/helpers/signers');
 const {
   AbiCoder,
+  ZeroHash,
   assertArgument,
   concat,
   dataLength,
   sha256,
-  toBeHex,
+  solidityPacked,
   toBigInt,
   encodeBase64,
   toUtf8Bytes,
@@ -86,7 +87,8 @@ class WebAuthnSigningKey extends P256SigningKey {
       challenge: encodeBase64(digest).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', ''),
     });
 
-    const authenticatorData = toBeHex(0n, 37); // equivalent to `hexlify(new Uint8Array(37))`
+    // Flags 0x05 = AUTH_DATA_FLAGS_UP | AUTH_DATA_FLAGS_UV
+    const authenticatorData = solidityPacked(['bytes32', 'bytes1', 'bytes4'], [ZeroHash, '0x05', '0x00000000']);
 
     // Regular P256 signature
     const { r, s } = super.sign(sha256(concat([authenticatorData, sha256(toUtf8Bytes(clientDataJSON))])));

--- a/test/utils/cryptography/WebAuthn.t.sol
+++ b/test/utils/cryptography/WebAuthn.t.sol
@@ -4,348 +4,181 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 import {P256} from "@openzeppelin/contracts/utils/cryptography/P256.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {Base64} from "@openzeppelin/contracts/utils/Base64.sol";
 import {WebAuthn} from "../../../contracts/utils/cryptography/WebAuthn.sol";
 
 contract WebAuthnTest is Test {
-    // solhint-disable-next-line quotes
-    string internal constant PREFIX = '{"type":"webauthn.get","challenge":"';
-    // solhint-disable-next-line quotes
-    string internal constant SUFFIX = '"}';
-
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyMinimal(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23, // Position of challenge in clientDataJSON
-            typeIndex: 1, // Position of type in clientDataJSON
-            r: r,
-            s: _ensureLowerS(s)
-        });
-
-        // Verify the signature
-        assertTrue(WebAuthn.verifyMinimal(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyMinimalInvalidType(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-
-        // Create client data JSON with invalid type
-        string memory clientDataJSON = string.concat(
-            // solhint-disable-next-line quotes
-            '{"type":"webauthn.create","challenge":"',
-            Base64.encodeURL(challenge),
-            SUFFIX
-        );
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23, // Position of challenge in clientDataJSON
-            typeIndex: 1, // Position of type in clientDataJSON
-            r: r,
-            s: _ensureLowerS(s)
-        });
-
-        // Verify the signature should fail due to invalid type
-        assertFalse(WebAuthn.verifyMinimal(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyMinimalInvalidChallenge(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-
-        // Create client data JSON with invalid challenge
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(bytes("invalid_challenge")), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23, // Position of challenge in clientDataJSON
-            typeIndex: 1, // Position of type in clientDataJSON
-            r: r,
-            s: _ensureLowerS(s)
-        });
-
-        // Verify the signature should fail due to invalid challenge
-        assertFalse(WebAuthn.verifyMinimal(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
     /// forge-config: default.fuzz.runs = 512
     function testFuzzVerify(bytes memory challenge, uint256 seed) public view {
+        assertTrue(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP),
+                _encodeClientDataJSON(challenge),
+                false
+            )
+        );
+    }
+
+    /// forge-config: default.fuzz.runs = 512
+    function testFuzzVerifyInvalidType(bytes memory challenge, uint256 seed) public view {
+        assertFalse(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_UV),
+                // solhint-disable-next-line quotes
+                string.concat('{"type":"webauthn.create","challenge":"', Base64.encodeURL(challenge), '"}'),
+                false
+            )
+        );
+    }
+
+    /// forge-config: default.fuzz.runs = 512
+    function testFuzzVerifyInvalidChallenge(bytes memory challenge, uint256 seed) public view {
+        assertFalse(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_UV),
+                _encodeClientDataJSON(bytes("invalid_challenge")),
+                false
+            )
+        );
+    }
+
+    /// forge-config: default.fuzz.runs = 512
+    function testFuzzVerifyFlagsUP(bytes memory challenge, uint256 seed) public view {
+        // UP = false: FAIL
+        assertFalse(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UV),
+                _encodeClientDataJSON(challenge),
+                false
+            )
+        );
+    }
+
+    /// forge-config: default.fuzz.runs = 512
+    function testFuzzVerifyFlagsUV(bytes memory challenge, uint256 seed) public view {
+        // UV = false, requireUV = false: SUCCESS
+        assertTrue(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP),
+                _encodeClientDataJSON(challenge),
+                false
+            )
+        );
+        // UV = false, requireUV = true: FAIL
+        assertFalse(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP),
+                _encodeClientDataJSON(challenge),
+                true
+            )
+        );
+        // UV = true, requireUV = true: SUCCESS
+        assertTrue(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_UV),
+                _encodeClientDataJSON(challenge),
+                true
+            )
+        );
+    }
+
+    /// forge-config: default.fuzz.runs = 512
+    function testFuzzVerifyFlagsBEBS(bytes memory challenge, uint256 seed) public view {
+        // BS = true, BE = false: FAIL
+        assertFalse(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(
+                    WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_UV | WebAuthn.AUTH_DATA_FLAGS_BS
+                ),
+                _encodeClientDataJSON(challenge),
+                false
+            )
+        );
+        // BS = false, BE = true: SUCCESS
+        assertTrue(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(
+                    WebAuthn.AUTH_DATA_FLAGS_UP | WebAuthn.AUTH_DATA_FLAGS_UV | WebAuthn.AUTH_DATA_FLAGS_BE
+                ),
+                _encodeClientDataJSON(challenge),
+                false
+            )
+        );
+        // BS = true, BE = true: SUCCESS
+        assertTrue(
+            _runVerify(
+                seed,
+                challenge,
+                _encodeAuthenticatorData(
+                    WebAuthn.AUTH_DATA_FLAGS_UP |
+                        WebAuthn.AUTH_DATA_FLAGS_UV |
+                        WebAuthn.AUTH_DATA_FLAGS_BE |
+                        WebAuthn.AUTH_DATA_FLAGS_BS
+                ),
+                _encodeClientDataJSON(challenge),
+                false
+            )
+        );
+    }
+
+    function _runVerify(
+        uint256 seed,
+        bytes memory challenge,
+        bytes memory authenticatorData,
+        string memory clientDataJSON,
+        bool requireUV
+    ) private view returns (bool) {
         // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
+        uint256 privateKey = bound(seed, 1, P256.N - 1);
         (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-        // Set User Present flag
-        authenticatorData[32] = bytes1(0x01);
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
 
         // Sign the message
         bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
         (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-        s = _ensureLowerS(s);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23, // Position of challenge in clientDataJSON
-            typeIndex: 1, // Position of type in clientDataJSON
-            r: r,
-            s: s
-        });
 
         // Verify the signature
-        assertTrue(WebAuthn.verify(challenge, auth, bytes32(x), bytes32(y)));
+        return
+            WebAuthn.verify(
+                challenge,
+                WebAuthn.WebAuthnAuth({
+                    authenticatorData: authenticatorData,
+                    clientDataJSON: clientDataJSON,
+                    challengeIndex: 23, // Position of challenge in clientDataJSON
+                    typeIndex: 1, // Position of type in clientDataJSON
+                    r: r,
+                    s: bytes32(Math.min(uint256(s), P256.N - uint256(s)))
+                }),
+                bytes32(x),
+                bytes32(y),
+                requireUV
+            );
     }
 
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyFailsWhenUpNotSet(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-        // Don't set User Present flag
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-        s = _ensureLowerS(s);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23, // Position of challenge in clientDataJSON
-            typeIndex: 1, // Position of type in clientDataJSON
-            r: r,
-            s: s
-        });
-
-        // Verify the signature should fail due to missing UP flag
-        assertFalse(WebAuthn.verify(challenge, auth, bytes32(x), bytes32(y)));
+    function _encodeAuthenticatorData(bytes1 flags) private pure returns (bytes memory) {
+        return abi.encodePacked(bytes32(0), flags, bytes4(0));
     }
 
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyStrict(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-        // Set User Present, User Verified, and Backup Eligibility flags
-        authenticatorData[32] = bytes1(0x0D); // UP (0x01) + UV (0x04) + BE (0x08)
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-        s = _ensureLowerS(s);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23, // Position of challenge in clientDataJSON
-            typeIndex: 1, // Position of type in clientDataJSON
-            r: r,
-            s: s
-        });
-
-        // Verify the signature
-        assertTrue(WebAuthn.verifyStrict(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
-    function testFuzzVerifyStrictFailsWithoutUV(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-        // Set only User Present flag, but not User Verified
-        authenticatorData[32] = bytes1(0x01); // Only UP (0x01) flag set
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-        s = _ensureLowerS(s);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23, // Position of challenge in clientDataJSON
-            typeIndex: 1, // Position of type in clientDataJSON
-            r: r,
-            s: s
-        });
-
-        // Verify the signature should fail due to missing UV flag
-        assertFalse(WebAuthn.verifyStrict(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyStrictFailsWithInvalidBEBS(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-        // Set UP, UV flags and invalid BE/BS combination (BE=0, BS=1)
-        authenticatorData[32] = bytes1(0x15); // UP (0x01) + UV (0x04) + BS (0x10) flags set
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-        s = _ensureLowerS(s);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23,
-            typeIndex: 1,
-            r: r,
-            s: s
-        });
-
-        // Verify the signature should fail due to invalid BE/BS combination
-        assertFalse(WebAuthn.verifyStrict(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyStrictSucceedsWithValidBEBSCombinations(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-        // Set UP, UV flags and valid BE/BS combinations
-        // Test all valid combinations: (BE=1,BS=0), (BE=1,BS=1), (BE=0,BS=0)
-        authenticatorData[32] = bytes1(0x0D); // UP (0x01) + UV (0x04) + BE (0x08) flags set
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-        s = _ensureLowerS(s);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23,
-            typeIndex: 1,
-            r: r,
-            s: s
-        });
-
-        // Verify the signature should succeed with valid BE/BS combination
-        assertTrue(WebAuthn.verifyStrict(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
-    /// forge-config: default.fuzz.runs = 512
-    function testFuzzVerifyStrictSucceedsWithAllFlagsSet(bytes memory challenge, uint256 seed) public view {
-        // Generate private key and get public key
-        uint256 privateKey = _asPrivateKey(seed);
-        (uint256 x, uint256 y) = vm.publicKeyP256(privateKey);
-
-        // Create authenticator data with minimum required length (37 bytes)
-        bytes memory authenticatorData = new bytes(37);
-        // Set all flags: UP, UV, BE, BS
-        authenticatorData[32] = bytes1(0x1D); // UP (0x01) + UV (0x04) + BE (0x08) + BS (0x10) flags set
-
-        // Create client data JSON with required fields
-        string memory clientDataJSON = string.concat(PREFIX, Base64.encodeURL(challenge), SUFFIX);
-
-        // Sign the message
-        bytes32 messageHash = sha256(abi.encodePacked(authenticatorData, sha256(bytes(clientDataJSON))));
-        (bytes32 r, bytes32 s) = vm.signP256(privateKey, messageHash);
-        s = _ensureLowerS(s);
-
-        // Create WebAuthnAuth struct
-        WebAuthn.WebAuthnAuth memory auth = WebAuthn.WebAuthnAuth({
-            authenticatorData: authenticatorData,
-            clientDataJSON: clientDataJSON,
-            challengeIndex: 23,
-            typeIndex: 1,
-            r: r,
-            s: s
-        });
-
-        // Verify the signature should succeed with all flags set
-        assertTrue(WebAuthn.verifyStrict(challenge, auth, bytes32(x), bytes32(y)));
-    }
-
-    function _asPrivateKey(uint256 seed) private pure returns (uint256) {
-        return bound(seed, 1, P256.N - 1);
-    }
-
-    function _ensureLowerS(bytes32 s) private pure returns (bytes32) {
-        uint256 _s = uint256(s);
-        unchecked {
-            return _s > P256.N / 2 ? bytes32(P256.N - _s) : s;
-        }
+    function _encodeClientDataJSON(bytes memory challenge) private pure returns (string memory) {
+        // solhint-disable-next-line quotes
+        return string.concat('{"type":"webauthn.get","challenge":"', Base64.encodeURL(challenge), '"}');
     }
 }


### PR DESCRIPTION
Observations

- Flags UP doesn't appear to be optional: enable it always
- Flags BE/BS are eaither not set (succes) or should be checks for inconsistency

Proposition:
- Create a variant of `verify` with a `requireUV` boolean
- Create a "default" variant of ` verify` that enables the UV check (equivalent to the old `verifyStrict`)
- Remove `verifyMinimal` with no way to reproduce it (UP check always on)
- Remove old `verify`, using the new `verify` (with bool) with false reproduces the "no UV check" part. BS-BE is still active
- Remove `verifyStrict`, the new `verify` (without boolean) has the same behavior.
- Use `verify` with UV in the signer/verifier. This is eqauivalent to using verifyStrict / requireUV 
  - this follows the recommandations of the M-04 issue.

Side changes:
- Update the helper to set the UP and UV flags
- Refactor the fuzzing tests