### PR TITLE
Update ERC7786Receiver

### DIFF
--- a/contracts/crosschain/axelar/AxelarGatewayDestination.sol
+++ b/contracts/crosschain/axelar/AxelarGatewayDestination.sol
@@ -39,9 +39,9 @@ abstract contract AxelarGatewayDestination is AxelarGatewayBase, AxelarExecutabl
         bytes calldata adapterPayload
     ) internal override {
         // Parse the package
-        (bytes memory sender, bytes memory recipient, bytes memory payload, bytes[] memory attributes) = abi.decode(
+        (bytes memory sender, bytes memory recipient, bytes memory payload) = abi.decode(
             adapterPayload,
-            (bytes, bytes, bytes, bytes[])
+            (bytes, bytes, bytes)
         );
 
         // Axelar to ERC-7930 translation
@@ -55,7 +55,7 @@ abstract contract AxelarGatewayDestination is AxelarGatewayBase, AxelarExecutabl
         );
 
         (, address target) = recipient.parseEvmV1();
-        bytes4 result = IERC7786Receiver(target).executeMessage(commandId, sender, payload, attributes);
-        require(result == IERC7786Receiver.executeMessage.selector, ReceiverExecutionFailed());
+        bytes4 result = IERC7786Receiver(target).receiveMessage(commandId, sender, payload);
+        require(result == IERC7786Receiver.receiveMessage.selector, ReceiverExecutionFailed());
     }
 }

--- a/contracts/crosschain/axelar/AxelarGatewaySource.sol
+++ b/contracts/crosschain/axelar/AxelarGatewaySource.sol
@@ -37,7 +37,7 @@ abstract contract AxelarGatewaySource is IERC7786GatewaySource, AxelarGatewayBas
 
         // Create the package
         bytes memory sender = InteroperableAddress.formatEvmV1(block.chainid, msg.sender);
-        bytes memory adapterPayload = abi.encode(sender, recipient, payload, attributes);
+        bytes memory adapterPayload = abi.encode(sender, recipient, payload);
 
         // Emit event
         sendId = bytes32(0); // Explicitly set to 0

--- a/contracts/crosschain/utils/ERC7786Receiver.sol
+++ b/contracts/crosschain/utils/ERC7786Receiver.sol
@@ -7,7 +7,7 @@ import {IERC7786Receiver} from "../../interfaces/IERC7786.sol";
 /**
  * @dev Base implementation of an ERC-7786 compliant cross-chain message receiver.
  *
- * This abstract contract exposes the `executeMessage` function that is used for communication with (one or multiple)
+ * This abstract contract exposes the `receiveMessage` function that is used for communication with (one or multiple)
  * destination gateways. This contract leaves two functions unimplemented:
  *
  * {_isKnownGateway}, an internal getter used to verify whether an address is recognised by the contract as a valid
@@ -21,15 +21,14 @@ abstract contract ERC7786Receiver is IERC7786Receiver {
     error ERC7786ReceivePassiveModeValue();
 
     /// @inheritdoc IERC7786Receiver
-    function executeMessage(
+    function receiveMessage(
         bytes32 receiveId,
         bytes calldata sender, // Binary Interoperable Address
-        bytes calldata payload,
-        bytes[] calldata attributes
+        bytes calldata payload
     ) public payable virtual returns (bytes4) {
         require(_isKnownGateway(msg.sender), ERC7786ReceiverInvalidGateway(msg.sender));
-        _processMessage(msg.sender, receiveId, sender, payload, attributes);
-        return IERC7786Receiver.executeMessage.selector;
+        _processMessage(msg.sender, receiveId, sender, payload);
+        return IERC7786Receiver.receiveMessage.selector;
     }
 
     /// @dev Virtual getter that returns whether an address is a valid ERC-7786 gateway.
@@ -40,7 +39,6 @@ abstract contract ERC7786Receiver is IERC7786Receiver {
         address gateway,
         bytes32 receiveId,
         bytes calldata sender,
-        bytes calldata payload,
-        bytes[] calldata attributes
+        bytes calldata payload
     ) internal virtual;
 }

--- a/contracts/interfaces/IERC7786.sol
+++ b/contracts/interfaces/IERC7786.sol
@@ -55,10 +55,9 @@ interface IERC7786Receiver {
      *
      * This function may be called directly by the gateway.
      */
-    function executeMessage(
+    function receiveMessage(
         bytes32 receiveId,
         bytes calldata sender, // Binary Interoperable Address
-        bytes calldata payload,
-        bytes[] calldata attributes
+        bytes calldata payload
     ) external payable returns (bytes4);
 }

--- a/contracts/mocks/crosschain/ERC7786GatewayMock.sol
+++ b/contracts/mocks/crosschain/ERC7786GatewayMock.sol
@@ -28,8 +28,8 @@ contract ERC7786GatewayMock is IERC7786GatewaySource {
 
         bytes memory sender = InteroperableAddress.formatEvmV1(block.chainid, msg.sender);
         require(
-            IERC7786Receiver(target).executeMessage(bytes32(0), sender, payload, attributes) ==
-                IERC7786Receiver.executeMessage.selector,
+            IERC7786Receiver(target).receiveMessage(bytes32(0), sender, payload) ==
+                IERC7786Receiver.receiveMessage.selector,
             "Receiver error"
         );
 

--- a/contracts/mocks/crosschain/ERC7786ReceiverInvalidMock.sol
+++ b/contracts/mocks/crosschain/ERC7786ReceiverInvalidMock.sol
@@ -5,12 +5,7 @@ pragma solidity ^0.8.0;
 import {IERC7786Receiver} from "../../interfaces/IERC7786.sol";
 
 contract ERC7786ReceiverInvalidMock is IERC7786Receiver {
-    function executeMessage(
-        bytes32,
-        bytes calldata,
-        bytes calldata,
-        bytes[] calldata
-    ) public payable virtual returns (bytes4) {
+    function receiveMessage(bytes32, bytes calldata, bytes calldata) public payable virtual returns (bytes4) {
         return 0xffffffff;
     }
 }

--- a/contracts/mocks/crosschain/ERC7786ReceiverMock.sol
+++ b/contracts/mocks/crosschain/ERC7786ReceiverMock.sol
@@ -7,7 +7,7 @@ import {ERC7786Receiver} from "../../crosschain/utils/ERC7786Receiver.sol";
 contract ERC7786ReceiverMock is ERC7786Receiver {
     address private immutable _gateway;
 
-    event MessageReceived(address gateway, bytes32 receiveId, bytes sender, bytes payload, bytes[] attributes);
+    event MessageReceived(address gateway, bytes32 receiveId, bytes sender, bytes payload);
 
     constructor(address gateway_) {
         _gateway = gateway_;
@@ -21,9 +21,8 @@ contract ERC7786ReceiverMock is ERC7786Receiver {
         address gateway,
         bytes32 receiveId,
         bytes calldata sender,
-        bytes calldata payload,
-        bytes[] calldata attributes
+        bytes calldata payload
     ) internal virtual override {
-        emit MessageReceived(gateway, receiveId, sender, payload, attributes);
+        emit MessageReceived(gateway, receiveId, sender, payload);
     }
 }

--- a/contracts/mocks/crosschain/ERC7786ReceiverRevertMock.sol
+++ b/contracts/mocks/crosschain/ERC7786ReceiverRevertMock.sol
@@ -5,12 +5,7 @@ pragma solidity ^0.8.0;
 import {IERC7786Receiver} from "../../interfaces/IERC7786.sol";
 
 contract ERC7786ReceiverRevertMock is IERC7786Receiver {
-    function executeMessage(
-        bytes32,
-        bytes calldata,
-        bytes calldata,
-        bytes[] calldata
-    ) public payable virtual returns (bytes4) {
+    function receiveMessage(bytes32, bytes calldata, bytes calldata) public payable virtual returns (bytes4) {
         revert();
     }
 }

--- a/contracts/mocks/docs/crosschain/MyERC7786ReceiverContract.sol
+++ b/contracts/mocks/docs/crosschain/MyERC7786ReceiverContract.sol
@@ -18,8 +18,7 @@ contract MyERC7786ReceiverContract is ERC7786Receiver, AccessManaged {
         address gateway,
         bytes32 receiveId,
         bytes calldata sender,
-        bytes calldata payload,
-        bytes[] calldata attributes
+        bytes calldata payload
     ) internal virtual override restricted {
         // Process the message here
     }

--- a/docs/modules/ROOT/pages/crosschain.adoc
+++ b/docs/modules/ROOT/pages/crosschain.adoc
@@ -14,9 +14,9 @@ To address the lack of composability in a simple and unopinionated way, ERC-7786
 
 The ERC defines a source and a destination gateway. Both are contracts that implement a protocol to send a message and process its reception respectively. These two processes are identified explicitly by the ERC-7786 specification since they define the minimal requirements for both gateways.
 
-* On the **source chain**, the contract implements a standard xref:api:crosschain.adoc#AxelarGatewaySource-sendMessage-string-string-bytes-bytes---[`sendMessage`] function and emits a xref:api:crosschain.adoc#AxelarGatewaySource-MessagePosted-bytes32-string-string-bytes-bytes---[`MessagePosted`] event to signal that the message should be relayed by the underlying protocol.
+* On the **source chain**, the contract implements a standard xref:api:crosschain.adoc#AxelarGatewaySource-sendMessage-string-string-bytes-[`sendMessage`] function and emits a xref:api:crosschain.adoc#AxelarGatewaySource-MessagePosted-bytes32-string-string-bytes-bytes---[`MessagePosted`] event to signal that the message should be relayed by the underlying protocol.
 
-* On the **destination chain**, the gateway receives the message and passes it to the receiver contract by calling the xref:api:crosschain.adoc#ERC7786Receiver-executeMessage-string-string-string-bytes-bytes---[`executeMessage`] function.
+* On the **destination chain**, the gateway receives the message and passes it to the receiver contract by calling the xref:api:crosschain.adoc#ERC7786Receiver-receiveMessage-string-string-string-bytes-bytes---[`receiveMessage`] function.
 
 Smart contract developers only need to worry about implementing the xref:api:crosschain.adoc#IERC7786GatewaySource[IERC7786GatewaySource] interface to send a message on the source chain and the xref:api:crosschain.adoc#IERC7786GatewaySource[IERC7786GatewaySource] and xref:api:crosschain.adoc#IERC7786Receiver[IERC7786Receiver] interface to receive such message on the destination chain.
 
@@ -48,9 +48,9 @@ NOTE: The standard represents chains using https://github.com/ChainAgnostic/CAIP
 
 === Receiving a message
 
-To successfully process a message on the destination chain, a destination gateway is required. Although ERC-7786 doesn't define a standard interface for the destination gateway, it requires that it calls the `executeMessage` upon message reception.
+To successfully process a message on the destination chain, a destination gateway is required. Although ERC-7786 doesn't define a standard interface for the destination gateway, it requires that it calls the `receiveMessage` upon message reception.
 
-Every cross-chain message protocol already offers a way to receive the message either through a canonical bridge or an intermediate contract. Developers can easily wrap the receiving contract into a gateway that calls the `executeMessage` function as mandated by the ERC.
+Every cross-chain message protocol already offers a way to receive the message either through a canonical bridge or an intermediate contract. Developers can easily wrap the receiving contract into a gateway that calls the `receiveMessage` function as mandated by the ERC.
 
 To receive a message on a custom smart contract, OpenZeppelin Community Contracts provide an xref:api:crosschain.adoc#ERC7786Receiver[ERC7786Receiver] implementation for developers to inherit. This way your contracts can receive a cross-chain message relayed through a known destination gateway gateway.
 
@@ -125,10 +125,10 @@ function sendMessage(
 }
 ```
 
-On the receiving end, the bridge implements a threshold-based confirmation system. Messages are only executed after receiving enough confirmations from the gateways, ensuring message validity and preventing double execution. The xref:api:crosschain.adoc#ERC7786OpenBridge-executeMessage-string-string-string-bytes-bytes---[`executeMessage`] function handles this process:
+On the receiving end, the bridge implements a threshold-based confirmation system. Messages are only executed after receiving enough confirmations from the gateways, ensuring message validity and preventing double execution. The xref:api:crosschain.adoc#ERC7786OpenBridge-receiveMessage-string-string-string-bytes-bytes---[`receiveMessage`] function handles this process:
 
 ```solidity
-function executeMessage(
+function receiveMessage(
     string calldata /*messageId*/, // gateway specific, empty or unique
     string calldata sourceChain, // CAIP-2 chain identifier
     string calldata sender, // CAIP-10 account address (does not include the chain identifier)
@@ -146,7 +146,7 @@ function executeMessage(
         emit Received(id, msg.sender);
 
         // if already executed, leave gracefully
-        if (tracker.executed) return IERC7786Receiver.executeMessage.selector;
+        if (tracker.executed) return IERC7786Receiver.receiveMessage.selector;
     } else if (tracker.executed) {
         revert ERC7786OpenBridgeAlreadyExecuted();
     }
@@ -160,7 +160,7 @@ function executeMessage(
 
         // ... Prepare execution context and validate state ...
         bytes memory call = abi.encodeCall(
-            IERC7786Receiver.executeMessage,
+            IERC7786Receiver.receiveMessage,
             (uint256(id).toHexString(32), sourceChain, originalSender, unwrappedPayload, attributes)
         );
 
@@ -169,7 +169,7 @@ function executeMessage(
         // ... Handle the result ...
     }
 
-    return IERC7786Receiver.executeMessage.selector;
+    return IERC7786Receiver.receiveMessage.selector;
 }
 ```
 

--- a/docs/modules/ROOT/pages/crosschain.adoc
+++ b/docs/modules/ROOT/pages/crosschain.adoc
@@ -14,9 +14,9 @@ To address the lack of composability in a simple and unopinionated way, ERC-7786
 
 The ERC defines a source and a destination gateway. Both are contracts that implement a protocol to send a message and process its reception respectively. These two processes are identified explicitly by the ERC-7786 specification since they define the minimal requirements for both gateways.
 
-* On the **source chain**, the contract implements a standard xref:api:crosschain.adoc#AxelarGatewaySource-sendMessage-string-string-bytes-[`sendMessage`] function and emits a xref:api:crosschain.adoc#AxelarGatewaySource-MessagePosted-bytes32-string-string-bytes-bytes---[`MessagePosted`] event to signal that the message should be relayed by the underlying protocol.
+* On the **source chain**, the contract implements a standard xref:api:crosschain.adoc#AxelarGatewaySource-sendMessage-bytes-bytes-bytes---[`sendMessage`] function and emits a xref:api:crosschain.adoc#AxelarGatewaySource-MessageSent-bytes32-string-string-bytes-bytes---[`MessageSent`] event to signal that the message should be relayed by the underlying protocol.
 
-* On the **destination chain**, the gateway receives the message and passes it to the receiver contract by calling the xref:api:crosschain.adoc#ERC7786Receiver-receiveMessage-string-string-string-bytes-bytes---[`receiveMessage`] function.
+* On the **destination chain**, the gateway receives the message and passes it to the receiver contract by calling the xref:api:crosschain.adoc#ERC7786Receiver-receiveMessage-bytes32-bytes-bytes-[`receiveMessage`] function.
 
 Smart contract developers only need to worry about implementing the xref:api:crosschain.adoc#IERC7786GatewaySource[IERC7786GatewaySource] interface to send a message on the source chain and the xref:api:crosschain.adoc#IERC7786GatewaySource[IERC7786GatewaySource] and xref:api:crosschain.adoc#IERC7786Receiver[IERC7786Receiver] interface to receive such message on the destination chain.
 
@@ -37,7 +37,7 @@ NOTE: Developers can register supported chains and destination gateways using th
 
 === Sending a message
 
-The interface for a source gateway is general enough that it allows wrapping a custom protocol to authenticate messages. Depending on the use case, developers can implement any offchain mechanism to read the standard xref:api:crosschain.adoc#IERC7786GatewaySource-MessagePosted-bytes32-string-string-bytes-bytes---[`MessagePosted`] event and deliver it to the receiver on the destination chain.
+The interface for a source gateway is general enough that it allows wrapping a custom protocol to authenticate messages. Depending on the use case, developers can implement any offchain mechanism to read the standard xref:api:crosschain.adoc#IERC7786GatewaySource-MessageSent-bytes32-string-string-bytes-bytes---[`MessageSent`] event and deliver it to the receiver on the destination chain.
 
 [source,solidity]
 ----

--- a/test/crosschain/ERC7786OpenBridge.test.js
+++ b/test/crosschain/ERC7786OpenBridge.test.js
@@ -154,7 +154,7 @@ describe('ERC7786OpenBridge', function () {
           if (this.outcome) {
             await expect(txPromise)
               .to.emit(this.destination, 'MessageReceived')
-              .withArgs(this.bridgeB, anyValue, this.chain.toErc7930(this.sender), this.payload, this.attributes)
+              .withArgs(this.bridgeB, anyValue, this.chain.toErc7930(this.sender), this.payload)
               .to.emit(this.bridgeB, 'ExecutionSuccess')
               .withArgs(resultId)
               .to.not.emit(this.bridgeB, 'ExecutionFailed');

--- a/test/crosschain/ERC7786Receiver.test.js
+++ b/test/crosschain/ERC7786Receiver.test.js
@@ -30,6 +30,6 @@ describe('ERC7786Receiver', function () {
       .to.emit(this.gateway, 'MessageSent')
       .withArgs(ethers.ZeroHash, this.toErc7930(this.sender), this.toErc7930(this.receiver), payload, 0n, attributes)
       .to.emit(this.receiver, 'MessageReceived')
-      .withArgs(this.gateway, anyValue, this.toErc7930(this.sender), payload, attributes); // ERC7786GatewayMock uses empty messageId
+      .withArgs(this.gateway, anyValue, this.toErc7930(this.sender), payload); // ERC7786GatewayMock uses empty messageId
   });
 });

--- a/test/crosschain/axelar/AxelarGateway.test.js
+++ b/test/crosschain/axelar/AxelarGateway.test.js
@@ -43,8 +43,8 @@ describe('AxelarGateway', function () {
     const payload = ethers.randomBytes(128);
     const attributes = [];
     const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
-      ['bytes', 'bytes', 'bytes', 'bytes[]'],
-      [erc7930Sender, erc7930Recipient, payload, attributes],
+      ['bytes', 'bytes', 'bytes'],
+      [erc7930Sender, erc7930Recipient, payload],
     );
 
     await expect(this.gatewayA.connect(this.sender).sendMessage(erc7930Recipient, payload, attributes))
@@ -55,7 +55,7 @@ describe('AxelarGateway', function () {
       .to.emit(this.axelar, 'MessageExecuted')
       .withArgs(anyValue)
       .to.emit(this.receiver, 'MessageReceived')
-      .withArgs(this.gatewayB, anyValue, erc7930Sender, payload, attributes);
+      .withArgs(this.gatewayB, anyValue, erc7930Sender, payload);
   });
 
   it('invalid receiver - bad return value', async function () {


### PR DESCRIPTION
Replace the old `executeMessage` (with attributes) to `receiveMessage` (without attributes).
Somehow that was missed.