### PR TITLE
Replace submodule with npm dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,10 +12,6 @@
 [submodule "lib/email-tx-builder"]
 	path = lib/email-tx-builder
 	url = https://github.com/zkemail/email-tx-builder
-[submodule "lib/axelar-gmp-sdk-solidity"]
-	path = lib/axelar-gmp-sdk-solidity
-	tag = v6.0.6
-	url = https://github.com/axelarnetwork/axelar-gmp-sdk-solidity
 [submodule "lib/zk-email-verify"]
 	path = lib/zk-email-verify
 	branch = v6.3.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@openzeppelin/community-contracts",
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "@axelar-network/axelar-gmp-sdk-solidity": "^6.0.6"
+      },
       "devDependencies": {
         "@openzeppelin/contracts": "file:lib/@openzeppelin-contracts",
         "husky": "^9.1.7"
@@ -88,6 +91,15 @@
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-6.0.6.tgz",
+      "integrity": "sha512-XIcDlr1HoYSqcxuvvusILmiqerh2bL9NJLwU4lFBAJK5E/st/q3Em9ropBBZML9iuUZ+hDsch8Ev9rMO+ulaSQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "security",
     "zeppelin"
   ],
+  "dependencies": {
+    "@axelar-network/axelar-gmp-sdk-solidity": "^6.0.6"
+  },
   "devDependencies": {
     "@openzeppelin/contracts": "file:lib/@openzeppelin-contracts",
     "husky": "^9.1.7"

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,6 +1,5 @@
 @openzeppelin/contracts/=lib/@openzeppelin-contracts/contracts/
 @openzeppelin/contracts-upgradeable/=lib/@openzeppelin-contracts-upgradeable/contracts/
 @openzeppelin/community-contracts/=contracts/
-@axelar-network/axelar-gmp-sdk-solidity/=lib/axelar-gmp-sdk-solidity/
 @zk-email/email-tx-builder/=lib/email-tx-builder/packages/contracts/
 @zk-email/contracts/=lib/zk-email-verify/packages/contracts/


### PR DESCRIPTION
Do we have any reason to favor submodules over npm packages ? IMO npm versionned packages are a better choice when available. I find them easier to track and update. 