### PR TITLE
Remove `templateId` and simplify EmailProof validation in ZKEmailUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 10-08-2025
+## 14-08-2025
 
 - `ZKEmailUtils`: Add `tryDecodeEmailProof` function for safe calldata decoding with comprehensive bounds checking and validation for `EmailProof` struct.
 - `ZKEmailUtils`: Update `isValidZKEmail` to receive `EmailProof` struct directly instead of `EmailAuthMsg` struct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 10-08-2025
+
+- `ZKEmailUtils`: Add `tryDecodeEmailProof` function for safe calldata decoding with comprehensive bounds checking and validation for `EmailProof` struct.
+- `ZKEmailUtils`: Update `isValidZKEmail` to receive `EmailProof` struct directly instead of `EmailAuthMsg` struct.
+- `SignerZKEmail`: Remove `templateId` functionality and switch from `EmailAuthMsg` to direct `EmailProof` validation for streamlined signature verification.
+- `ERC7913ZKEmailVerifier`: Remove `templateId` from signature validation logic and update `_decodeKey` function to directly decode `EmailProof` struct.
+
 ## 09-08-2025
 
 - `ZKEmailUtils`: Simplify library implementation and remove `Verifier.sol` indirection for cleaner integration with a Groth16Verifier.

--- a/contracts/mocks/account/AccountZKEmailMock.sol
+++ b/contracts/mocks/account/AccountZKEmailMock.sol
@@ -15,13 +15,11 @@ contract AccountZKEmailMock is Account, SignerZKEmail, ERC7739, ERC7821, ERC721H
     constructor(
         bytes32 accountSalt_,
         IDKIMRegistry registry_,
-        IGroth16Verifier groth16Verifier_,
-        uint256 templateId_
+        IGroth16Verifier groth16Verifier_
     ) EIP712("AccountZKEmailMock", "1") {
         _setAccountSalt(accountSalt_);
         _setDKIMRegistry(registry_);
         _setVerifier(groth16Verifier_);
-        _setTemplateId(templateId_);
     }
 
     /// @inheritdoc ERC7821

--- a/contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol
+++ b/contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.8.24;
 
-import {IDKIMRegistry} from "@zk-email/contracts/DKIMRegistry.sol";
-import {IGroth16Verifier} from "@zk-email/email-tx-builder/src/interfaces/IGroth16Verifier.sol";
-import {EmailAuthMsg} from "@zk-email/email-tx-builder/src/interfaces/IEmailTypes.sol";
 import {IERC7913SignatureVerifier} from "@openzeppelin/contracts/interfaces/IERC7913.sol";
+import {IDKIMRegistry} from "@zk-email/contracts/DKIMRegistry.sol";
+import {EmailProof} from "@zk-email/email-tx-builder/src/interfaces/IEmailTypes.sol";
+import {IGroth16Verifier} from "@zk-email/email-tx-builder/src/interfaces/IGroth16Verifier.sol";
 import {ZKEmailUtils} from "../ZKEmailUtils.sol";
 
 /**
@@ -16,59 +16,53 @@ import {ZKEmailUtils} from "../ZKEmailUtils.sol";
  *
  * The key decoding logic is customizable: users may override the {_decodeKey} function
  * to enforce restrictions or validation on the decoded values (e.g., requiring a specific
- * verifier, templateId, or registry). To remain compliant with ERC-7913's statelessness,
+ * verifier or registry). To remain compliant with ERC-7913's statelessness,
  * it is recommended to enforce such restrictions using immutable variables only.
  *
- * Example of overriding _decodeKey to enforce a specific verifier, registry, (or templateId):
+ * Example of overriding _decodeKey to enforce a specific verifier, registry:
  *
  * ```solidity
  *   function _decodeKey(bytes calldata key) internal view override returns (
  *       IDKIMRegistry registry,
  *       bytes32 accountSalt,
- *       IGroth16Verifier verifier,
- *       uint256 templateId
+ *       IGroth16Verifier verifier
  *   ) {
- *       (registry, accountSalt, verifier, templateId) = super._decodeKey(key);
+ *       (registry, accountSalt, verifier) = super._decodeKey(key);
  *       require(verifier == _verifier, "Invalid verifier");
  *       require(registry == _registry, "Invalid registry");
- *       return (registry, accountSalt, verifier, templateId);
+ *       return (registry, accountSalt, verifier);
  *   }
  * ```
  */
 contract ERC7913ZKEmailVerifier is IERC7913SignatureVerifier {
-    using ZKEmailUtils for EmailAuthMsg;
+    using ZKEmailUtils for EmailProof;
 
     /**
      * @dev Verifies a zero-knowledge proof of an email signature validated by a {DKIMRegistry} contract.
      *
-     * The key format is ABI-encoded (IDKIMRegistry, bytes32, IGroth16Verifier, uint256) where:
+     * The key format is ABI-encoded (IDKIMRegistry, bytes32, IGroth16Verifier) where:
      *
      * * IDKIMRegistry: The registry contract that validates DKIM public key hashes
      * * bytes32: The account salt that uniquely identifies the user's email address
      * * IGroth16Verifier: The verifier contract instance for ZK proof verification.
-     * * uint256: The template ID for the command
      *
      * See {_decodeKey} for the key encoding format.
      *
-     * The signature is an ABI-encoded {ZKEmailUtils-EmailAuthMsg} struct containing
-     * the command parameters, template ID, and proof details.
+     * The signature is an ABI-encoded {EmailProof} struct containing
+     * the proof details.
      *
      * Signature encoding:
      *
      * ```solidity
-     * bytes memory signature = abi.encode(EmailAuthMsg({
-     *     templateId: 1,
-     *     commandParams: [hash],
-     *     proof: {
-     *         domainName: "example.com", // The domain name of the email sender
-     *         publicKeyHash: bytes32(0x...), // Hash of the DKIM public key used to sign the email
-     *         timestamp: block.timestamp, // When the email was sent
-     *         maskedCommand: "Sign hash", // The command being executed, with sensitive data masked
-     *         emailNullifier: bytes32(0x...), // Unique identifier for the email to prevent replay attacks
-     *         accountSalt: bytes32(0x...), // Unique identifier derived from email and account code
-     *         isCodeExist: true, // Whether the account code exists in the proof
-     *         proof: bytes(0x...) // The zero-knowledge proof verifying the email's authenticity
-     *     }
+     * bytes memory signature = abi.encode(EmailProof({
+     *     domainName: "example.com", // The domain name of the email sender
+     *     publicKeyHash: bytes32(0x...), // Hash of the DKIM public key used to sign the email
+     *     timestamp: block.timestamp, // When the email was sent
+     *     maskedCommand: "signHash 12345...", // The command being executed, with sensitive data masked
+     *     emailNullifier: bytes32(0x...), // Unique identifier for the email to prevent replay attacks
+     *     accountSalt: bytes32(0x...), // Unique identifier derived from email and account code
+     *     isCodeExist: true, // Whether the account code exists in the proof
+     *     proof: bytes(0x...) // The zero-knowledge proof verifying the email's authenticity
      * }));
      * ```
      */
@@ -77,16 +71,13 @@ contract ERC7913ZKEmailVerifier is IERC7913SignatureVerifier {
         bytes32 hash,
         bytes calldata signature
     ) public view virtual override returns (bytes4) {
-        (IDKIMRegistry registry_, bytes32 accountSalt_, IGroth16Verifier verifier_, uint256 templateId_) = _decodeKey(
-            key
-        );
-        EmailAuthMsg memory emailAuthMsg = abi.decode(signature, (EmailAuthMsg));
+        (IDKIMRegistry registry_, bytes32 accountSalt_, IGroth16Verifier verifier_) = _decodeKey(key);
+        (bool decodeSuccess, EmailProof calldata emailProof) = ZKEmailUtils.tryDecodeEmailProof(signature);
 
         return
-            (abi.decode(emailAuthMsg.commandParams[0], (bytes32)) == hash &&
-                emailAuthMsg.templateId == templateId_ &&
-                emailAuthMsg.proof.accountSalt == accountSalt_ &&
-                emailAuthMsg.isValidZKEmail(registry_, verifier_) == ZKEmailUtils.EmailProofError.NoError)
+            (decodeSuccess &&
+                emailProof.accountSalt == accountSalt_ &&
+                emailProof.isValidZKEmail(registry_, verifier_, hash) == ZKEmailUtils.EmailProofError.NoError)
                 ? IERC7913SignatureVerifier.verify.selector
                 : bytes4(0xffffffff);
     }
@@ -95,17 +86,12 @@ contract ERC7913ZKEmailVerifier is IERC7913SignatureVerifier {
      * @dev Decodes the key into its components.
      *
      * ```solidity
-     * bytes memory key = abi.encode(registry, accountSalt, verifier, templateId);
+     * bytes memory key = abi.encode(registry, accountSalt, verifier);
      * ```
      */
     function _decodeKey(
         bytes calldata key
-    )
-        internal
-        view
-        virtual
-        returns (IDKIMRegistry registry, bytes32 accountSalt, IGroth16Verifier verifier, uint256 templateId)
-    {
-        return abi.decode(key, (IDKIMRegistry, bytes32, IGroth16Verifier, uint256));
+    ) internal view virtual returns (IDKIMRegistry registry, bytes32 accountSalt, IGroth16Verifier verifier) {
+        return abi.decode(key, (IDKIMRegistry, bytes32, IGroth16Verifier));
     }
 }

--- a/test/account/AccountERC7913.test.js
+++ b/test/account/AccountERC7913.test.js
@@ -19,12 +19,11 @@ const selector = '12345';
 const domainName = 'gmail.com';
 const publicKeyHash = '0x0ea9c777dc7110e5a9e89b13f0cfc540e3845ba120b2b6dc24024d61488d4788';
 const emailNullifier = '0x00a83fce3d4b1c9ef0f600644c1ecc6c8115b57b1596e0e3295e2c5105fbfd8a';
-const templateId = ethers.solidityPackedKeccak256(['string', 'uint256'], ['TEST', 0n]);
 
 // Prepare signer in advance
 const signerWebAuthn = new NonNativeSigner(WebAuthnSigningKey.random());
 const signerZKEmail = new NonNativeSigner(
-  new ZKEmailSigningKey(domainName, publicKeyHash, emailNullifier, accountSalt, templateId),
+  new ZKEmailSigningKey(domainName, publicKeyHash, emailNullifier, accountSalt),
 );
 
 // Minimal fixture common to the different signer verifiers
@@ -117,8 +116,8 @@ describe('AccountERC7913', function () {
         ethers.concat([
           this.verifierZKEmail.target,
           ethers.AbiCoder.defaultAbiCoder().encode(
-            ['address', 'bytes32', 'address', 'uint256'],
-            [this.dkim.target, accountSalt, this.zkEmailVerifier.target, templateId],
+            ['address', 'bytes32', 'address'],
+            [this.dkim.target, accountSalt, this.zkEmailVerifier.target],
           ),
         ]),
       );

--- a/test/helpers/enums.js
+++ b/test/helpers/enums.js
@@ -6,7 +6,6 @@ module.exports = {
     'NoError',
     'DKIMPublicKeyHash',
     'MaskedCommandLength',
-    'SkippedCommandPrefixSize',
     'MismatchedCommand',
     'InvalidFieldPoint',
     'EmailProof',

--- a/test/helpers/signers.js
+++ b/test/helpers/signers.js
@@ -17,14 +17,12 @@ class ZKEmailSigningKey {
   #publicKeyHash;
   #emailNullifier;
   #accountSalt;
-  #templateId;
 
-  constructor(domainName, publicKeyHash, emailNullifier, accountSalt, templateId) {
+  constructor(domainName, publicKeyHash, emailNullifier, accountSalt) {
     this.#domainName = domainName;
     this.#publicKeyHash = publicKeyHash;
     this.#emailNullifier = emailNullifier;
     this.#accountSalt = accountSalt;
-    this.#templateId = templateId;
     this.SIGN_HASH_COMMAND = 'signHash';
   }
 
@@ -60,26 +58,19 @@ class ZKEmailSigningKey {
     const pC = [7n, 8n];
     const validProof = AbiCoder.defaultAbiCoder().encode(['uint256[2]', 'uint256[2][2]', 'uint256[2]'], [pA, pB, pC]);
 
-    // Encode the email auth message as the signature
+    // Encode the EmailProof as the signature
     return {
       serialized: AbiCoder.defaultAbiCoder().encode(
-        ['tuple(uint256,bytes[],uint256,tuple(string,bytes32,uint256,string,bytes32,bytes32,bool,bytes))'],
+        ['string', 'bytes32', 'uint256', 'string', 'bytes32', 'bytes32', 'bool', 'bytes'],
         [
-          [
-            this.#templateId,
-            [digest],
-            0, // skippedCommandPrefix
-            [
-              this.#domainName,
-              this.#publicKeyHash,
-              timestamp,
-              command,
-              this.#emailNullifier,
-              this.#accountSalt,
-              isCodeExist,
-              validProof,
-            ],
-          ],
+          this.#domainName,
+          this.#publicKeyHash,
+          timestamp,
+          command,
+          this.#emailNullifier,
+          this.#accountSalt,
+          isCodeExist,
+          validProof,
         ],
       ),
     };

--- a/test/utils/cryptography/ZKEmailUtils.t.sol
+++ b/test/utils/cryptography/ZKEmailUtils.t.sol
@@ -15,15 +15,11 @@ import {EmailAuthMsgFixtures, EmailAuthMsg} from "@zk-email/email-tx-builder/tes
 
 contract ZKEmailUtilsTest is Test {
     using Strings for *;
-    using ZKEmailUtils for EmailAuthMsg;
-
-    // Base field size
-    uint256 constant Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+    using ZKEmailUtils for EmailProof;
 
     IDKIMRegistry private _dkimRegistry;
     IGroth16Verifier private _verifier;
     bytes32 private _accountSalt;
-    uint256 private _templateId;
     // From https://github.com/zkemail/email-tx-builder/blob/main/packages/contracts/test/helpers/DeploymentHelper.sol#L36-L41
     string private _selector = "1234";
     string private _domainName = "gmail.com";
@@ -42,21 +38,28 @@ contract ZKEmailUtilsTest is Test {
 
         // Generate test data
         _accountSalt = keccak256("test@example.com");
-        _templateId = 1;
         _mockProof = abi.encodePacked(bytes1(0x01));
     }
 
     function testFixtureCase1SignHash() public {
         EmailAuthMsg memory authMsg = EmailAuthMsgFixtures.getCase1();
         _setupDKIMRegistryForFixture(authMsg);
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(authMsg, _dkimRegistry, _verifier);
+        ZKEmailUtils.EmailProofError err = authMsg.proof.isValidZKEmail(
+            _dkimRegistry,
+            _verifier,
+            abi.decode(authMsg.commandParams[0], (bytes32))
+        );
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.NoError));
     }
 
     function testFixtureCase2SignHash() public {
         EmailAuthMsg memory authMsg = EmailAuthMsgFixtures.getCase2();
         _setupDKIMRegistryForFixture(authMsg);
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(authMsg, _dkimRegistry, _verifier);
+        ZKEmailUtils.EmailProofError err = authMsg.proof.isValidZKEmail(
+            _dkimRegistry,
+            _verifier,
+            abi.decode(authMsg.commandParams[0], (bytes32))
+        );
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.NoError));
     }
 
@@ -72,10 +75,11 @@ contract ZKEmailUtilsTest is Test {
         template[4] = CommandUtils.ETH_ADDR_MATCHER;
 
         ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            authMsg,
+            authMsg.proof,
             _dkimRegistry,
             _verifier,
             template,
+            authMsg.commandParams,
             ZKEmailUtils.Case.ANY
         );
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.NoError));
@@ -91,10 +95,11 @@ contract ZKEmailUtilsTest is Test {
         template[2] = CommandUtils.ETH_ADDR_MATCHER;
 
         ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            authMsg,
+            authMsg.proof,
             _dkimRegistry,
             _verifier,
             template,
+            authMsg.commandParams,
             ZKEmailUtils.Case.ANY
         );
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.NoError));
@@ -113,31 +118,20 @@ contract ZKEmailUtilsTest is Test {
         (pA, pB, pC) = _boundPoints(pA, pB, pC);
         bytes memory proof = abi.encode(pA, pB, pC);
 
-        // Build email auth message with fuzzed parameters
-        bytes[] memory commandParams = new bytes[](1);
-        commandParams[0] = abi.encode(hash);
-
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(
-            string.concat(SIGN_HASH_COMMAND, uint256(hash).toString()),
-            commandParams,
-            0
-        );
+        // Build email proof with fuzzed parameters
+        EmailProof memory emailProof = _buildEmailProofMock(string.concat(SIGN_HASH_COMMAND, uint256(hash).toString()));
 
         // Override with fuzzed values
-        emailAuthMsg.proof.timestamp = timestamp;
-        emailAuthMsg.proof.emailNullifier = emailNullifier;
-        emailAuthMsg.proof.accountSalt = accountSalt;
-        emailAuthMsg.proof.isCodeExist = isCodeExist;
-        emailAuthMsg.proof.proof = proof;
+        emailProof.timestamp = timestamp;
+        emailProof.emailNullifier = emailNullifier;
+        emailProof.accountSalt = accountSalt;
+        emailProof.isCodeExist = isCodeExist;
+        emailProof.proof = proof;
 
         _mockVerifyEmailProof();
 
         // Test validation
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
-            IDKIMRegistry(_dkimRegistry),
-            _verifier
-        );
+        ZKEmailUtils.EmailProofError err = emailProof.isValidZKEmail(IDKIMRegistry(_dkimRegistry), _verifier, hash);
 
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.NoError));
     }
@@ -159,18 +153,16 @@ contract ZKEmailUtilsTest is Test {
         bytes[] memory commandParams = new bytes[](1);
         commandParams[0] = abi.encode(hash);
 
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(
-            string.concat(commandPrefix, " ", uint256(hash).toString()),
-            commandParams,
-            0
+        EmailProof memory emailProof = _buildEmailProofMock(
+            string.concat(commandPrefix, " ", uint256(hash).toString())
         );
 
         // Override with fuzzed values
-        emailAuthMsg.proof.timestamp = timestamp;
-        emailAuthMsg.proof.emailNullifier = emailNullifier;
-        emailAuthMsg.proof.accountSalt = accountSalt;
-        emailAuthMsg.proof.isCodeExist = isCodeExist;
-        emailAuthMsg.proof.proof = proof;
+        emailProof.timestamp = timestamp;
+        emailProof.emailNullifier = emailNullifier;
+        emailProof.accountSalt = accountSalt;
+        emailProof.isCodeExist = isCodeExist;
+        emailProof.proof = proof;
 
         string[] memory template = new string[](2);
         template[0] = commandPrefix;
@@ -179,10 +171,11 @@ contract ZKEmailUtilsTest is Test {
         _mockVerifyEmailProof();
 
         ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
+            emailProof,
             IDKIMRegistry(_dkimRegistry),
             _verifier,
-            template
+            template,
+            commandParams
         );
 
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.NoError));
@@ -207,18 +200,16 @@ contract ZKEmailUtilsTest is Test {
 
         // Test with different cases
         for (uint256 i = 0; i < uint8(type(ZKEmailUtils.Case).max) - 1; i++) {
-            EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(
-                string.concat(commandPrefix, " ", CommandUtils.addressToHexString(addr, i)),
-                commandParams,
-                0
+            EmailProof memory emailProof = _buildEmailProofMock(
+                string.concat(commandPrefix, " ", CommandUtils.addressToHexString(addr, i))
             );
 
             // Override with fuzzed values
-            emailAuthMsg.proof.timestamp = timestamp;
-            emailAuthMsg.proof.emailNullifier = emailNullifier;
-            emailAuthMsg.proof.accountSalt = accountSalt;
-            emailAuthMsg.proof.isCodeExist = isCodeExist;
-            emailAuthMsg.proof.proof = proof;
+            emailProof.timestamp = timestamp;
+            emailProof.emailNullifier = emailNullifier;
+            emailProof.accountSalt = accountSalt;
+            emailProof.isCodeExist = isCodeExist;
+            emailProof.proof = proof;
 
             _mockVerifyEmailProof();
 
@@ -227,10 +218,11 @@ contract ZKEmailUtilsTest is Test {
             template[1] = CommandUtils.ETH_ADDR_MATCHER;
 
             ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-                emailAuthMsg,
+                emailProof,
                 IDKIMRegistry(_dkimRegistry),
                 _verifier,
                 template,
+                commandParams,
                 ZKEmailUtils.Case(i)
             );
             assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.NoError));
@@ -254,18 +246,14 @@ contract ZKEmailUtilsTest is Test {
         bytes[] memory commandParams = new bytes[](1);
         commandParams[0] = abi.encode(addr);
 
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(
-            string.concat(commandPrefix, " ", addr.toHexString()),
-            commandParams,
-            0
-        );
+        EmailProof memory emailProof = _buildEmailProofMock(string.concat(commandPrefix, " ", addr.toHexString()));
 
         // Override with fuzzed values
-        emailAuthMsg.proof.timestamp = timestamp;
-        emailAuthMsg.proof.emailNullifier = emailNullifier;
-        emailAuthMsg.proof.accountSalt = accountSalt;
-        emailAuthMsg.proof.isCodeExist = isCodeExist;
-        emailAuthMsg.proof.proof = proof;
+        emailProof.timestamp = timestamp;
+        emailProof.emailNullifier = emailNullifier;
+        emailProof.accountSalt = accountSalt;
+        emailProof.isCodeExist = isCodeExist;
+        emailProof.proof = proof;
 
         string[] memory template = new string[](2);
         template[0] = commandPrefix;
@@ -274,10 +262,11 @@ contract ZKEmailUtilsTest is Test {
         _mockVerifyEmailProof();
 
         ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
+            emailProof,
             IDKIMRegistry(_dkimRegistry),
             _verifier,
             template,
+            commandParams,
             ZKEmailUtils.Case.ANY
         );
 
@@ -285,23 +274,12 @@ contract ZKEmailUtilsTest is Test {
     }
 
     function testInvalidDKIMPublicKeyHash(bytes32 hash, string memory domainName, bytes32 publicKeyHash) public view {
-        bytes[] memory commandParams = new bytes[](1);
-        commandParams[0] = abi.encode(hash);
+        EmailProof memory emailProof = _buildEmailProofMock(string.concat(SIGN_HASH_COMMAND, uint256(hash).toString()));
 
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(
-            string.concat(SIGN_HASH_COMMAND, uint256(hash).toString()),
-            commandParams,
-            0
-        );
+        emailProof.domainName = domainName;
+        emailProof.publicKeyHash = publicKeyHash;
 
-        emailAuthMsg.proof.domainName = domainName;
-        emailAuthMsg.proof.publicKeyHash = publicKeyHash;
-
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
-            IDKIMRegistry(_dkimRegistry),
-            _verifier
-        );
+        ZKEmailUtils.EmailProofError err = emailProof.isValidZKEmail(IDKIMRegistry(_dkimRegistry), _verifier, hash);
 
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.DKIMPublicKeyHash));
     }
@@ -309,53 +287,17 @@ contract ZKEmailUtilsTest is Test {
     function testInvalidMaskedCommandLength(bytes32 hash, uint256 length) public view {
         length = bound(length, 606, 1000); // Assuming commandBytes is 605
 
-        bytes[] memory commandParams = new bytes[](1);
-        commandParams[0] = abi.encode(hash);
+        EmailProof memory emailProof = _buildEmailProofMock(string(new bytes(length)));
 
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(string(new bytes(length)), commandParams, 0);
-
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
-            IDKIMRegistry(_dkimRegistry),
-            _verifier
-        );
+        ZKEmailUtils.EmailProofError err = emailProof.isValidZKEmail(IDKIMRegistry(_dkimRegistry), _verifier, hash);
 
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.MaskedCommandLength));
     }
 
-    function testSkippedCommandPrefix(bytes32 hash, uint256 skippedPrefix) public view {
-        uint256 verifierCommandBytes = ZKEmailUtils.COMMAND_BYTES;
-        skippedPrefix = bound(skippedPrefix, verifierCommandBytes, verifierCommandBytes + 1000);
-
-        bytes[] memory commandParams = new bytes[](1);
-        commandParams[0] = abi.encode(hash);
-
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(
-            string.concat(SIGN_HASH_COMMAND, uint256(hash).toString()),
-            commandParams,
-            skippedPrefix
-        );
-
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
-            IDKIMRegistry(_dkimRegistry),
-            _verifier
-        );
-
-        assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.SkippedCommandPrefixSize));
-    }
-
     function testMismatchedCommand(bytes32 hash, string memory invalidCommand) public view {
-        bytes[] memory commandParams = new bytes[](1);
-        commandParams[0] = abi.encode(hash);
+        EmailProof memory emailProof = _buildEmailProofMock(invalidCommand);
 
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(invalidCommand, commandParams, 0);
-
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
-            IDKIMRegistry(_dkimRegistry),
-            _verifier
-        );
+        ZKEmailUtils.EmailProofError err = emailProof.isValidZKEmail(IDKIMRegistry(_dkimRegistry), _verifier, hash);
 
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.MismatchedCommand));
     }
@@ -368,24 +310,236 @@ contract ZKEmailUtilsTest is Test {
     ) public view {
         (pA, pB, pC) = _boundPoints(pA, pB, pC);
 
-        bytes[] memory commandParams = new bytes[](1);
-        commandParams[0] = abi.encode(hash);
+        EmailProof memory emailProof = _buildEmailProofMock(string.concat(SIGN_HASH_COMMAND, uint256(hash).toString()));
 
-        EmailAuthMsg memory emailAuthMsg = _buildEmailAuthMsgMock(
-            string.concat(SIGN_HASH_COMMAND, uint256(hash).toString()),
-            commandParams,
-            0
-        );
+        emailProof.proof = abi.encode(pA, pB, pC);
 
-        emailAuthMsg.proof.proof = abi.encode(pA, pB, pC);
-
-        ZKEmailUtils.EmailProofError err = ZKEmailUtils.isValidZKEmail(
-            emailAuthMsg,
-            IDKIMRegistry(_dkimRegistry),
-            _verifier
-        );
+        ZKEmailUtils.EmailProofError err = emailProof.isValidZKEmail(IDKIMRegistry(_dkimRegistry), _verifier, hash);
 
         assertEq(uint256(err), uint256(ZKEmailUtils.EmailProofError.EmailProof));
+    }
+
+    function testTryDecodeEmailProofValid(
+        string memory domainName,
+        bytes32 publicKeyHash,
+        uint256 timestamp,
+        string memory maskedCommand,
+        bytes32 emailNullifier,
+        bytes32 accountSalt,
+        bool isCodeExist,
+        bytes memory proof
+    ) public view {
+        (bool success, EmailProof memory emailProof) = this.tryDecodeEmailProof(
+            abi.encode(
+                domainName,
+                publicKeyHash,
+                timestamp,
+                maskedCommand,
+                emailNullifier,
+                accountSalt,
+                isCodeExist,
+                proof
+            )
+        );
+        assertTrue(success);
+        assertEq(emailProof.domainName, domainName);
+        assertEq(emailProof.publicKeyHash, publicKeyHash);
+        assertEq(emailProof.timestamp, timestamp);
+        assertEq(emailProof.maskedCommand, maskedCommand);
+        assertEq(emailProof.emailNullifier, emailNullifier);
+        assertEq(emailProof.accountSalt, accountSalt);
+        assertEq(emailProof.isCodeExist, isCodeExist);
+        assertEq(emailProof.proof, proof);
+    }
+
+    function testTryDecodeEmailProofInvalid() public view {
+        string memory domainName = "gmail.com";
+        bytes32 publicKeyHash = keccak256("publicKeyHash");
+        uint256 timestamp = block.timestamp;
+        string memory maskedCommand = "signHash 12345";
+        bytes32 emailNullifier = keccak256("emailNullifier");
+        bytes32 accountSalt = keccak256("accountSalt");
+        bool isCodeExist = true;
+        bytes memory proof = hex"deadbeef";
+
+        // too short
+        assertFalse(
+            this.tryDecodeEmailProofDrop(abi.encodePacked(publicKeyHash, timestamp, emailNullifier, accountSalt))
+        );
+
+        // offset out of bound for domainName (position 0x00)
+        bytes memory encoded = abi.encodePacked(
+            abi.encodePacked(
+                uint256(0x200), // domainName offset pointing outside
+                publicKeyHash,
+                timestamp,
+                uint256(0x160), // maskedCommand offset
+                emailNullifier,
+                accountSalt,
+                isCodeExist
+            ),
+            abi.encodePacked(
+                uint256(0x180), // proof offset
+                uint256(bytes(domainName).length),
+                domainName,
+                uint256(bytes(maskedCommand).length),
+                maskedCommand,
+                uint256(proof.length),
+                proof
+            )
+        );
+        assertFalse(this.tryDecodeEmailProofDrop(encoded));
+
+        // offset out of bound for maskedCommand (position 0x60)
+        encoded = abi.encodePacked(
+            abi.encodePacked(
+                uint256(0x100), // domainName offset
+                publicKeyHash,
+                timestamp,
+                uint256(0x200), // maskedCommand offset pointing outside
+                emailNullifier,
+                accountSalt,
+                isCodeExist
+            ),
+            abi.encodePacked(
+                uint256(0x140), // proof offset
+                uint256(bytes(domainName).length),
+                domainName,
+                uint256(bytes(maskedCommand).length),
+                maskedCommand,
+                uint256(proof.length),
+                proof
+            )
+        );
+        assertFalse(this.tryDecodeEmailProofDrop(encoded));
+
+        // offset out of bound for proof (position 0xe0)
+        encoded = abi.encodePacked(
+            abi.encodePacked(
+                uint256(0x100), // domainName offset
+                publicKeyHash,
+                timestamp,
+                uint256(0x120), // maskedCommand offset
+                emailNullifier,
+                accountSalt,
+                isCodeExist
+            ),
+            abi.encodePacked(
+                uint256(0x200), // proof offset pointing outside
+                uint256(bytes(domainName).length),
+                domainName,
+                uint256(bytes(maskedCommand).length),
+                maskedCommand,
+                uint256(proof.length),
+                proof
+            )
+        );
+        assertFalse(this.tryDecodeEmailProofDrop(encoded));
+
+        // minimal valid (all dynamic fields length 0, at the same position)
+        assertTrue(
+            this.tryDecodeEmailProofDrop(
+                abi.encodePacked(
+                    uint256(0x100), // domainName offset
+                    publicKeyHash,
+                    timestamp,
+                    uint256(0x100), // maskedCommand offset
+                    emailNullifier,
+                    accountSalt,
+                    isCodeExist ? bytes32(uint256(1)) : bytes32(0),
+                    uint256(0x100), // proof offset
+                    uint256(0) // length 0 for all dynamic fields
+                )
+            )
+        );
+
+        // length out of bound for domainName
+        assertTrue(
+            this.tryDecodeEmailProofDrop(
+                abi.encodePacked(
+                    uint256(0x100), // domainName offset
+                    publicKeyHash,
+                    timestamp,
+                    uint256(0x120), // maskedCommand offset
+                    emailNullifier,
+                    accountSalt,
+                    isCodeExist ? bytes32(uint256(1)) : bytes32(0),
+                    uint256(0x140), // proof offset
+                    uint256(0x20), // domainName length 32 bytes
+                    bytes32(0), // 32 bytes of domain data
+                    uint256(0), // maskedCommand length 0
+                    uint256(0) // proof length 0
+                )
+            )
+        );
+
+        // length pointing outside buffer for domainName
+        assertFalse(
+            this.tryDecodeEmailProofDrop(
+                abi.encodePacked(
+                    uint256(0x100), // domainName offset
+                    publicKeyHash,
+                    timestamp,
+                    uint256(0x120), // maskedCommand offset
+                    emailNullifier,
+                    accountSalt,
+                    isCodeExist ? bytes32(uint256(1)) : bytes32(0),
+                    uint256(0x140), // proof offset
+                    uint256(0x61), // domainName length 97 (32 * 3 + 1) bytes (too long for available data)
+                    bytes32(0), // only 32 bytes of domain data
+                    uint256(0), // maskedCommand length 0
+                    uint256(0) // proof length 0
+                )
+            )
+        );
+
+        // valid case with proper offsets and lengths
+        assertTrue(
+            this.tryDecodeEmailProofDrop(
+                abi.encodePacked(
+                    uint256(0x100), // domainName offset
+                    publicKeyHash,
+                    timestamp,
+                    uint256(0x120), // maskedCommand offset
+                    emailNullifier,
+                    accountSalt,
+                    isCodeExist ? bytes32(uint256(1)) : bytes32(0),
+                    uint256(0x140), // proof offset
+                    uint256(0), // domainName length 0
+                    uint256(0), // maskedCommand length 0
+                    uint256(0) // proof length 0
+                )
+            )
+        );
+
+        // invalid case with length pointing outside for proof
+        assertFalse(
+            this.tryDecodeEmailProofDrop(
+                abi.encodePacked(
+                    uint256(0x100), // domainName offset
+                    publicKeyHash,
+                    timestamp,
+                    uint256(0x120), // maskedCommand offset
+                    emailNullifier,
+                    accountSalt,
+                    isCodeExist ? bytes32(uint256(1)) : bytes32(0),
+                    uint256(0x140), // proof offset
+                    uint256(0), // domainName length 0
+                    uint256(0), // maskedCommand length 0
+                    uint256(0x01) // proof length 1 (but no data provided)
+                )
+            )
+        );
+    }
+
+    function tryDecodeEmailProof(
+        bytes calldata encoded
+    ) public pure returns (bool success, EmailProof calldata emailProof) {
+        (success, emailProof) = ZKEmailUtils.tryDecodeEmailProof(encoded);
+    }
+
+    function tryDecodeEmailProofDrop(bytes calldata encoded) public pure returns (bool success) {
+        (success, ) = ZKEmailUtils.tryDecodeEmailProof(encoded);
     }
 
     function _createECDSAOwnedDKIMRegistry() private returns (IDKIMRegistry) {
@@ -407,12 +561,8 @@ contract ZKEmailUtilsTest is Test {
         );
     }
 
-    function _buildEmailAuthMsgMock(
-        string memory command,
-        bytes[] memory params,
-        uint256 skippedPrefix
-    ) private view returns (EmailAuthMsg memory emailAuthMsg) {
-        EmailProof memory emailProof = EmailProof({
+    function _buildEmailProofMock(string memory command) private view returns (EmailProof memory emailProof) {
+        emailProof = EmailProof({
             domainName: _domainName,
             publicKeyHash: _publicKeyHash,
             timestamp: block.timestamp,
@@ -421,13 +571,6 @@ contract ZKEmailUtilsTest is Test {
             accountSalt: _accountSalt,
             isCodeExist: true,
             proof: _mockProof
-        });
-
-        emailAuthMsg = EmailAuthMsg({
-            templateId: _templateId,
-            commandParams: params,
-            skippedCommandPrefix: skippedPrefix,
-            proof: emailProof
         });
     }
 
@@ -455,6 +598,7 @@ contract ZKEmailUtilsTest is Test {
         uint256[2][2] memory pB,
         uint256[2] memory pC
     ) private pure returns (uint256[2] memory, uint256[2][2] memory, uint256[2] memory) {
+        uint256 Q = ZKEmailUtils.Q;
         pA[0] = bound(pA[0], 1, Q - 1);
         pA[1] = bound(pA[1], 1, Q - 1);
         pB[0][0] = bound(pB[0][0], 1, Q - 1);


### PR DESCRIPTION
This PR streamlines the ZKEmailUtils by receiving an EmailProof directly instead of an EmailAuthMsg struct. From the original struct, the `templateId` was unused and not included in the proof so anyone can construct the expected value, so it was removed.

On the `SignerZKEmail` and `ERC7913ZKEmailVerifier` side, their implementation was simplified following changes in ZKEmailUtils.

**Key Changes:**
- Remove `templateId` and `skippedCommandPrefix` functionality across all ZKEmail contracts
- Add robust `tryDecodeEmailProof` function for safe calldata decoding with comprehensive bounds checking
- Update signature encoding in tests to use direct `EmailProof` field encoding
- Maintain security through existing DKIM verification and zero-knowledge proof validation

The simplified implementation reduces complexity while preserving all essential security guarantees.