### PR TITLE
Add DKIMRegistry docs, changelog entry and CODEWONERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,3 +20,4 @@
 /contracts/utils/cryptography/ZKEmailUtils.sol @zkfriendly @benceharomi
 /contracts/utils/cryptography/signers/SignerZKEmail.sol @zkfriendly @benceharomi
 /contracts/utils/cryptography/verifiers/ERC7913ZKEmailVerifier.sol @zkfriendly @benceharomi
+/contracts/utils/cryptography/DKIMRegistry.sol @0xknon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 09-09-2025
 
-- `DKIMRegistry`: Add implementation of ERC-7969 to enable on-chain verification of DomainKeys Identified Mail (DKIM) signatures.
+- `DKIMRegistry`: Add implementation of ERC-7969 to enable onchain verification of DomainKeys Identified Mail (DKIM) signatures.
 
 ## 17-08-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 09-09-2025
+
+- `DKIMRegistry`: Add implementation of ERC-7969 to enable on-chain verification of DomainKeys Identified Mail (DKIM) signatures.
+
 ## 17-08-2025
 
 - `ERC20Freezable`: Add extension of ERC-20 that allows freezing specific amounts of tokens per account, preventing transfers until unfrozen while maintaining full visibility of balances.

--- a/contracts/utils/cryptography/DKIMRegistry.sol
+++ b/contracts/utils/cryptography/DKIMRegistry.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.26;
 import {IDKIMRegistry} from "../../interfaces/IERC7969.sol";
 
 /**
- * @dev Implementation of {IDKIMRegistry} for registering and validating DKIM public key hashes onchain.
+ * @dev Implementation of the https://eips.ethereum.org/EIPS/eip-7969[ERC-7969] interface for registering
+ * and validating DomainKeys Identified Mail (DKIM) public key hashes onchain.
  *
  * This contract provides a standard way to register and validate DKIM public key hashes, enabling
  * email-based account abstraction and secure account recovery mechanisms. Domain owners can register

--- a/contracts/utils/cryptography/README.adoc
+++ b/contracts/utils/cryptography/README.adoc
@@ -10,12 +10,15 @@ A collection of contracts and libraries that implement various signature validat
  * {SignerZKEmail}: Implementation of an https://docs.openzeppelin.com/contracts/5.x/api/utils/cryptography#AbstractSigner[AbstractSigner] that enables email-based authentication through zero-knowledge proofs.
  * {SignerWebAuthn}: Implementation of https://docs.openzeppelin.com/contracts/5.x/api/utils/cryptography#SignerP256[SignerP256] that supports WebAuthn authentication assertions.
  * {ERC7913ZKEmailVerifier}, {ERC7913WebAuthnVerifier}: Ready to use ERC-7913 signature verifiers for ZKEmail and WebAuthn.
+ * {DKIMRegistry}: Implementation of https://eips.ethereum.org/EIPS/eip-7969[ERC-7969] to enable on-chain verification of DomainKeys Identified Mail (DKIM) signatures.
 
 == Utils
 
 {{ZKEmailUtils}}
 
 {{WebAuthn}}
+
+{{DKIMRegistry}}
 
 == Abstract Signers
 

--- a/contracts/utils/cryptography/README.adoc
+++ b/contracts/utils/cryptography/README.adoc
@@ -10,7 +10,7 @@ A collection of contracts and libraries that implement various signature validat
  * {SignerZKEmail}: Implementation of an https://docs.openzeppelin.com/contracts/5.x/api/utils/cryptography#AbstractSigner[AbstractSigner] that enables email-based authentication through zero-knowledge proofs.
  * {SignerWebAuthn}: Implementation of https://docs.openzeppelin.com/contracts/5.x/api/utils/cryptography#SignerP256[SignerP256] that supports WebAuthn authentication assertions.
  * {ERC7913ZKEmailVerifier}, {ERC7913WebAuthnVerifier}: Ready to use ERC-7913 signature verifiers for ZKEmail and WebAuthn.
- * {DKIMRegistry}: Implementation of https://eips.ethereum.org/EIPS/eip-7969[ERC-7969] to enable on-chain verification of DomainKeys Identified Mail (DKIM) signatures.
+ * {DKIMRegistry}: Implementation of https://eips.ethereum.org/EIPS/eip-7969[ERC-7969] to enable onchain verification of DomainKeys Identified Mail (DKIM) signatures.
 
 == Utils
 

--- a/contracts/utils/cryptography/README.adoc
+++ b/contracts/utils/cryptography/README.adoc
@@ -7,10 +7,10 @@ A collection of contracts and libraries that implement various signature validat
 
  * {ZKEmailUtils}: Library for ZKEmail signature validation utilities, enabling email-based authentication through zero-knowledge proofs.
  * {WebAuthn}: Library for verifying WebAuthn Authentication Assertions.
+ * {DKIMRegistry}: Implementation of https://eips.ethereum.org/EIPS/eip-7969[ERC-7969] to enable onchain verification of DomainKeys Identified Mail (DKIM) signatures.
  * {SignerZKEmail}: Implementation of an https://docs.openzeppelin.com/contracts/5.x/api/utils/cryptography#AbstractSigner[AbstractSigner] that enables email-based authentication through zero-knowledge proofs.
  * {SignerWebAuthn}: Implementation of https://docs.openzeppelin.com/contracts/5.x/api/utils/cryptography#SignerP256[SignerP256] that supports WebAuthn authentication assertions.
  * {ERC7913ZKEmailVerifier}, {ERC7913WebAuthnVerifier}: Ready to use ERC-7913 signature verifiers for ZKEmail and WebAuthn.
- * {DKIMRegistry}: Implementation of https://eips.ethereum.org/EIPS/eip-7969[ERC-7969] to enable onchain verification of DomainKeys Identified Mail (DKIM) signatures.
 
 == Utils
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce DKIMRegistry implementation for on-chain DKIM verification and update supporting files

New Features:
- Add DKIMRegistry implementing ERC-7969 for on-chain DomainKeys Identified Mail signature verification

Documentation:
- Add changelog entry for DKIMRegistry release (09-09-2025)
- Document DKIMRegistry in contracts/utils/cryptography/README.adoc

Chores:
- Add CODEOWNERS entry for DKIMRegistry files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced DKIMRegistry cryptography utility for on-chain DKIM signature verification under Utils.
* Documentation
  * Added DKIMRegistry entry and anchors to the cryptography README.
  * Updated CHANGELOG with a new 2025-09-09 section highlighting DKIMRegistry.
* Chores
  * Updated code ownership rules to cover the DKIMRegistry path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->