### PR TITLE
Handle zero-divisor in `_consumeClaimable*` after partial-claim rounding

### DIFF
--- a/contracts/token/ERC20/extensions/ERC7540.sol
+++ b/contracts/token/ERC20/extensions/ERC7540.sol
@@ -409,7 +409,6 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540 {
      *
      * * `assets` must not exceed {maxDeposit} for the relevant account.
      * * When async, `msg.sender` must be `controller` or an approved operator of `controller`.
-     * * `assets` must not be 0 if {maxDeposit} is 0 for `controller` or `receiver`. Panics with division by zero otherwise.
      */
     function deposit(
         uint256 assets,

--- a/contracts/token/ERC20/extensions/ERC7540AdminDeposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540AdminDeposit.sol
@@ -93,14 +93,11 @@ abstract contract ERC7540AdminDeposit is ERC7540 {
         emit DepositClaimable(controller, 0, assets, shares);
     }
 
-    /**
-     * @dev Consumes `assets` from the claimable deposit and returns the proportional shares (rounded down).
-     *
-     * Requirements:
-     *
-     * * {maxMint} must not be 0 for `controller`. Panics with division by zero otherwise.
-     */
+    /// @dev Consumes `assets` from the claimable deposit and returns the proportional shares (rounded down).
     function _consumeClaimableDeposit(uint256 assets, address controller) internal virtual override returns (uint256) {
+        // When `assets` equals the controller's full claimable balance (including the case where both
+        // sides are 0), the entire remaining `claimableShares` is returned and consumed. This drains any
+        // residue left after a partial claim was rounded against the share side.
         uint256 maxAssets = maxDeposit(controller);
         uint256 maxShares = maxMint(controller);
         uint256 shares = assets == maxAssets
@@ -114,6 +111,9 @@ abstract contract ERC7540AdminDeposit is ERC7540 {
 
     /// @dev Consumes `shares` from the claimable deposit and returns the proportional assets (rounded up).
     function _consumeClaimableMint(uint256 shares, address controller) internal virtual override returns (uint256) {
+        // When `shares` equals the controller's full claimable balance (including the case where both
+        // sides are 0), the entire remaining `claimableAssets` is returned and consumed. This drains any
+        // residue left after a partial claim was rounded against the asset side.
         uint256 maxAssets = maxDeposit(controller);
         uint256 maxShares = maxMint(controller);
         uint256 assets = shares == maxShares

--- a/contracts/token/ERC20/extensions/ERC7540AdminDeposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540AdminDeposit.sol
@@ -101,7 +101,12 @@ abstract contract ERC7540AdminDeposit is ERC7540 {
      * * {maxMint} must not be 0 for `controller`. Panics with division by zero otherwise.
      */
     function _consumeClaimableDeposit(uint256 assets, address controller) internal virtual override returns (uint256) {
-        uint256 shares = Math.mulDiv(assets, maxMint(controller), maxDeposit(controller), Math.Rounding.Floor);
+        uint256 maxAssets = maxDeposit(controller);
+        uint256 maxShares = maxMint(controller);
+        uint256 shares = assets == maxAssets
+            ? maxShares
+            : Math.mulDiv(assets, maxShares, maxAssets, Math.Rounding.Floor);
+
         _deposits[controller].claimableAssets -= assets;
         _deposits[controller].claimableShares -= shares;
         return shares;
@@ -109,7 +114,12 @@ abstract contract ERC7540AdminDeposit is ERC7540 {
 
     /// @dev Consumes `shares` from the claimable deposit and returns the proportional assets (rounded up).
     function _consumeClaimableMint(uint256 shares, address controller) internal virtual override returns (uint256) {
-        uint256 assets = Math.mulDiv(shares, maxDeposit(controller), maxMint(controller), Math.Rounding.Ceil);
+        uint256 maxAssets = maxDeposit(controller);
+        uint256 maxShares = maxMint(controller);
+        uint256 assets = shares == maxShares
+            ? maxAssets
+            : Math.mulDiv(shares, maxAssets, maxShares, Math.Rounding.Ceil);
+
         _deposits[controller].claimableAssets -= assets;
         _deposits[controller].claimableShares -= shares;
         return assets;

--- a/contracts/token/ERC20/extensions/ERC7540AdminRedeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540AdminRedeem.sol
@@ -90,7 +90,12 @@ abstract contract ERC7540AdminRedeem is ERC7540 {
 
     /// @dev Consumes `assets` from the claimable redeem and returns the proportional shares (rounded up).
     function _consumeClaimableWithdraw(uint256 assets, address controller) internal virtual override returns (uint256) {
-        uint256 shares = Math.mulDiv(assets, maxRedeem(controller), maxWithdraw(controller), Math.Rounding.Ceil);
+        uint256 maxAssets = maxWithdraw(controller);
+        uint256 maxShares = maxRedeem(controller);
+        uint256 shares = assets == maxAssets
+            ? maxShares
+            : Math.mulDiv(assets, maxShares, maxAssets, Math.Rounding.Ceil);
+
         _redeems[controller].claimableAssets -= assets;
         _redeems[controller].claimableShares -= shares;
         return shares;
@@ -98,7 +103,12 @@ abstract contract ERC7540AdminRedeem is ERC7540 {
 
     /// @dev Consumes `shares` from the claimable redeem and returns the proportional assets (rounded down).
     function _consumeClaimableRedeem(uint256 shares, address controller) internal virtual override returns (uint256) {
-        uint256 assets = Math.mulDiv(shares, maxWithdraw(controller), maxRedeem(controller), Math.Rounding.Floor);
+        uint256 maxShares = maxRedeem(controller);
+        uint256 maxAssets = maxWithdraw(controller);
+        uint256 assets = shares == maxShares
+            ? maxAssets
+            : Math.mulDiv(shares, maxAssets, maxShares, Math.Rounding.Floor);
+
         _redeems[controller].claimableAssets -= assets;
         _redeems[controller].claimableShares -= shares;
         return assets;

--- a/contracts/token/ERC20/extensions/ERC7540AdminRedeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540AdminRedeem.sol
@@ -90,6 +90,9 @@ abstract contract ERC7540AdminRedeem is ERC7540 {
 
     /// @dev Consumes `assets` from the claimable redeem and returns the proportional shares (rounded up).
     function _consumeClaimableWithdraw(uint256 assets, address controller) internal virtual override returns (uint256) {
+        // When `assets` equals the controller's full claimable balance (including the case where both
+        // sides are 0), the entire remaining `claimableShares` is returned and consumed. This drains any
+        // residue left after a partial claim was rounded against the share side.
         uint256 maxAssets = maxWithdraw(controller);
         uint256 maxShares = maxRedeem(controller);
         uint256 shares = assets == maxAssets
@@ -103,6 +106,9 @@ abstract contract ERC7540AdminRedeem is ERC7540 {
 
     /// @dev Consumes `shares` from the claimable redeem and returns the proportional assets (rounded down).
     function _consumeClaimableRedeem(uint256 shares, address controller) internal virtual override returns (uint256) {
+        // When `shares` equals the controller's full claimable balance (including the case where both
+        // sides are 0), the entire remaining `claimableAssets` is returned and consumed. This drains any
+        // residue left after a partial claim was rounded against the asset side.
         uint256 maxShares = maxRedeem(controller);
         uint256 maxAssets = maxWithdraw(controller);
         uint256 assets = shares == maxShares

--- a/test/token/ERC20/extensions/ERC7540.behavior.js
+++ b/test/token/ERC20/extensions/ERC7540.behavior.js
@@ -306,6 +306,14 @@ function shouldBehaveLikeERC7540Deposit({
               .to.be.revertedWithCustomError(this.mock, 'ERC7540InvalidOperator')
               .withArgs(this.controller, this.other);
           });
+
+          it('empty deposit when nothing is claimable', async function () {
+            const tx = this.mock
+              .connect(this.controller)
+              .deposit(0n, this.receiver, ethers.Typed.address(this.controller));
+            await expect(tx).to.emit(this.mock, 'Deposit').withArgs(this.controller, this.receiver, 0n, 0n);
+            await expect(tx).to.changeTokenBalance(this.mock, this.receiver, 0n);
+          });
         });
 
         describe('via mint()', function () {
@@ -363,6 +371,14 @@ function shouldBehaveLikeERC7540Deposit({
             )
               .to.be.revertedWithCustomError(this.mock, 'ERC7540InvalidOperator')
               .withArgs(this.controller, this.other);
+          });
+
+          it('empty mint when nothing is claimable', async function () {
+            const tx = this.mock
+              .connect(this.controller)
+              .mint(0n, this.receiver, ethers.Typed.address(this.controller));
+            await expect(tx).to.emit(this.mock, 'Deposit').withArgs(this.controller, this.receiver, 0n, 0n);
+            await expect(tx).to.changeTokenBalance(this.mock, this.receiver, 0n);
           });
         });
       });
@@ -625,6 +641,14 @@ function shouldBehaveLikeERC7540Redeem({ initialAssets, initialShares, balance, 
               .to.be.revertedWithCustomError(this.mock, 'ERC7540InvalidOperator')
               .withArgs(this.controller, this.other);
           });
+
+          it('empty redeem when nothing is claimable', async function () {
+            const tx = this.mock.connect(this.controller).redeem(0n, this.receiver, this.controller);
+            await expect(tx)
+              .to.emit(this.mock, 'Withdraw')
+              .withArgs(this.controller, this.receiver, this.controller, 0n, 0n);
+            await expect(tx).to.changeTokenBalances(this.token, [this.mock, this.receiver], [0n, 0n]);
+          });
         });
 
         describe('via withdraw()', function () {
@@ -669,6 +693,14 @@ function shouldBehaveLikeERC7540Redeem({ initialAssets, initialShares, balance, 
             await expect(this.mock.connect(this.other).withdraw(assets, this.receiver, this.controller))
               .to.be.revertedWithCustomError(this.mock, 'ERC7540InvalidOperator')
               .withArgs(this.controller, this.other);
+          });
+
+          it('empty withdraw when nothing is claimable', async function () {
+            const tx = this.mock.connect(this.controller).withdraw(0n, this.receiver, this.controller);
+            await expect(tx)
+              .to.emit(this.mock, 'Withdraw')
+              .withArgs(this.controller, this.receiver, this.controller, 0n, 0n);
+            await expect(tx).to.changeTokenBalances(this.token, [this.mock, this.receiver], [0n, 0n]);
           });
         });
       });

--- a/test/token/ERC20/extensions/ERC7540Admin.test.js
+++ b/test/token/ERC20/extensions/ERC7540Admin.test.js
@@ -15,7 +15,8 @@ const tokenName = 'Asset Token';
 const tokenSymbol = 'AST';
 
 describe('ERC7540Admin', function () {
-  for (const withTmpHolder of [false, true]) {
+  // for (const withTmpHolder of [false, true]) {
+  for (const withTmpHolder of [false]) {
     describe(withTmpHolder ? 'With a temporary share holder' : 'With direct share operations', function () {
       async function fixture() {
         const token = await ethers.deployContract('$ERC20', [tokenName, tokenSymbol]);
@@ -267,6 +268,74 @@ describe('ERC7540Admin', function () {
           await expect(this.mock.maxRedeem(user)).to.eventually.equal(0n);
           await expect(this.mock.maxWithdraw(user)).to.eventually.equal(0n);
           await expect(this.token.balanceOf(user)).to.eventually.equal(42n);
+        });
+      });
+
+      describe('rounding corner cases', function () {
+        it('deposit flow - rounding shares to 0 and deposit', async function () {
+          const [, user] = await ethers.getSigners();
+          await this.token.$_mint(user, 1000n);
+          await this.token.connect(user).approve(this.mock, ethers.MaxUint256);
+
+          await expect(this.mock.claimableDepositRequest(0n, user)).to.eventually.equal(0n);
+          await expect(this.mock.maxDeposit(user)).to.eventually.equal(0n);
+          await expect(this.mock.maxMint(user)).to.eventually.equal(0n);
+          await expect(this.mock.balanceOf(user)).to.eventually.equal(0n);
+
+          await this.mock.connect(user).requestDeposit(100n, user, user);
+          await this.fulfillDeposit(0n, 1n, 100n, user);
+
+          await expect(this.mock.claimableDepositRequest(0n, user)).to.eventually.equal(1n);
+          await expect(this.mock.maxDeposit(user)).to.eventually.equal(1n);
+          await expect(this.mock.maxMint(user)).to.eventually.equal(100n);
+          await expect(this.mock.balanceOf(user)).to.eventually.equal(0n);
+
+          await this.mock.connect(user).mint(1n, user); // 1 share => 1 asset
+
+          await expect(this.mock.claimableDepositRequest(0n, user)).to.eventually.equal(0n);
+          await expect(this.mock.maxDeposit(user)).to.eventually.equal(0n);
+          await expect(this.mock.maxMint(user)).to.eventually.equal(99n);
+          await expect(this.mock.balanceOf(user)).to.eventually.equal(1n);
+
+          await this.mock.connect(user).deposit(0n, user); // 0 assets => 99 shares
+
+          await expect(this.mock.claimableDepositRequest(0n, user)).to.eventually.equal(0n);
+          await expect(this.mock.maxDeposit(user)).to.eventually.equal(0n);
+          await expect(this.mock.maxMint(user)).to.eventually.equal(0n);
+          await expect(this.mock.balanceOf(user)).to.eventually.equal(100n);
+        });
+
+        it('redeem flow - rounding shares to 0 and redeem', async function () {
+          const [, user] = await ethers.getSigners();
+          await this.token.$_mint(this.mock, 1000n);
+          await this.mock.$_mint(user, 1000n);
+
+          await expect(this.mock.claimableRedeemRequest(0n, user)).to.eventually.equal(0n);
+          await expect(this.mock.maxRedeem(user)).to.eventually.equal(0n);
+          await expect(this.mock.maxWithdraw(user)).to.eventually.equal(0n);
+          await expect(this.token.balanceOf(user)).to.eventually.equal(0n);
+
+          await this.mock.connect(user).requestRedeem(100n, user, user);
+          await this.fulfillRedeem(0n, 100n, 1n, user);
+
+          await expect(this.mock.claimableRedeemRequest(0n, user)).to.eventually.equal(1n);
+          await expect(this.mock.maxRedeem(user)).to.eventually.equal(1n);
+          await expect(this.mock.maxWithdraw(user)).to.eventually.equal(100n);
+          await expect(this.token.balanceOf(user)).to.eventually.equal(0n);
+
+          await this.mock.connect(user).withdraw(1n, user, user); // 1 assets => 1 shares
+
+          await expect(this.mock.claimableRedeemRequest(0n, user)).to.eventually.equal(0n);
+          await expect(this.mock.maxRedeem(user)).to.eventually.equal(0n);
+          await expect(this.mock.maxWithdraw(user)).to.eventually.equal(99n);
+          await expect(this.token.balanceOf(user)).to.eventually.equal(1n);
+
+          await this.mock.connect(user).redeem(0n, user, user); // 0 shares => 99 assets
+
+          await expect(this.mock.claimableRedeemRequest(0n, user)).to.eventually.equal(0n);
+          await expect(this.mock.maxRedeem(user)).to.eventually.equal(0n);
+          await expect(this.mock.maxWithdraw(user)).to.eventually.equal(0n);
+          await expect(this.token.balanceOf(user)).to.eventually.equal(100n);
         });
       });
     });

--- a/test/token/ERC20/extensions/ERC7540Admin.test.js
+++ b/test/token/ERC20/extensions/ERC7540Admin.test.js
@@ -15,8 +15,7 @@ const tokenName = 'Asset Token';
 const tokenSymbol = 'AST';
 
 describe('ERC7540Admin', function () {
-  // for (const withTmpHolder of [false, true]) {
-  for (const withTmpHolder of [false]) {
+  for (const withTmpHolder of [false, true]) {
     describe(withTmpHolder ? 'With a temporary share holder' : 'With direct share operations', function () {
       async function fixture() {
         const token = await ethers.deployContract('$ERC20', [tokenName, tokenSymbol]);


### PR DESCRIPTION
Following https://audits.openzeppelin.com/openzeppelin-solidity/project/openzeppelin-community-contracts/41249254-ce3c-4bfa-8684-4c7863c775e7/issue/rounding-in-consumeclaimablewithdraw-can-exhaust-claimable-shares-before-assets-skewing-totalsupply-and-erc-4626-conversions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized deposit and redemption processing to improve performance through streamlined calculations for exact match scenarios.

* **Tests**
  * Added test coverage for rounding edge cases in deposit and redeem flows near conversion limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->