### PR TITLE
Document (and check) that ERC7540Delay modules do no use temporary share custody

### DIFF
--- a/contracts/mocks/token/ERC7540DelayMock.sol
+++ b/contracts/mocks/token/ERC7540DelayMock.sol
@@ -39,3 +39,15 @@ abstract contract ERC7540DelayMock is ERC7540DelayDeposit, ERC7540DelayRedeem {
         return super._requestRedeem(shares, controller, owner, requestId);
     }
 }
+
+abstract contract ERC7540DelayShareOriginMock is ERC7540DelayMock {
+    function _depositShareOrigin() internal view virtual override returns (address) {
+        return address(this);
+    }
+}
+
+abstract contract ERC7540DelayShareDestinationMock is ERC7540DelayMock {
+    function _redeemShareDestination() internal view virtual override returns (address) {
+        return address(this);
+    }
+}

--- a/contracts/token/ERC20/extensions/ERC7540DelayDeposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540DelayDeposit.sol
@@ -31,8 +31,8 @@ import {ERC7540} from "./ERC7540.sol";
  * change the time source (default: `block.timestamp`).
  *
  * NOTE: This module does not support temporary share custody through {_depositShareOrigin}. The constructor
- * will try enforce that property, but this check may not be enough if {_depositShareOrigin} is implemented
- * using a view mechanism that is not yet initialize during the parent's construction.
+ * tries to enforce that property, but the check may be insufficient if {_depositShareOrigin} reads from
+ * storage that is not yet initialized when the parent's constructor runs
  */
 abstract contract ERC7540DelayDeposit is ERC7540, IERC6372 {
     using SafeCast for uint256;
@@ -41,7 +41,7 @@ abstract contract ERC7540DelayDeposit is ERC7540, IERC6372 {
     mapping(address controller => Checkpoints.Trace208) private _deposits;
     mapping(address controller => uint256) private _claimedDeposits;
 
-    /// @dev Triggered if _depositShareOrigin() is not address(0), as this is not supported by this module.
+    /// @dev Triggered if {_depositShareOrigin} is not address(0), as this is not supported by this module.
     error ERC7540DelayInvalidDepositShareOrigin();
 
     constructor() {

--- a/contracts/token/ERC20/extensions/ERC7540DelayDeposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540DelayDeposit.sol
@@ -29,6 +29,10 @@ import {ERC7540} from "./ERC7540.sol";
  *
  * Override {depositDelay} to customize the waiting period (default: 1 hour) and {clock} to
  * change the time source (default: `block.timestamp`).
+ *
+ * NOTE: This module does not support temporary share custody through {_depositShareOrigin}. The constructor
+ * will try enforce that property, but this check may not be enough if {_depositShareOrigin} is implemented
+ * using a view mechanism that is not yet initialize during the parent's construction.
  */
 abstract contract ERC7540DelayDeposit is ERC7540, IERC6372 {
     using SafeCast for uint256;
@@ -36,6 +40,13 @@ abstract contract ERC7540DelayDeposit is ERC7540, IERC6372 {
 
     mapping(address controller => Checkpoints.Trace208) private _deposits;
     mapping(address controller => uint256) private _claimedDeposits;
+
+    /// @dev Triggered if _depositShareOrigin() is not address(0), as this is not supported by this module.
+    error ERC7540DelayInvalidDepositShareOrigin();
+
+    constructor() {
+        require(_depositShareOrigin() == address(0), ERC7540DelayInvalidDepositShareOrigin());
+    }
 
     /// @inheritdoc IERC6372
     function clock() public view virtual returns (uint48) {

--- a/contracts/token/ERC20/extensions/ERC7540DelayRedeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540DelayRedeem.sol
@@ -29,6 +29,10 @@ import {ERC7540} from "./ERC7540.sol";
  *
  * Override {redeemDelay} to customize the waiting period (default: 1 hour) and {clock} to
  * change the time source (default: `block.timestamp`).
+ *
+ * NOTE: This module does not support temporary share custody through {_redeemShareDestination}. the constructor
+ * will try enforce that property, but this check may not be enough if {_redeemShareDestination} is implemented
+ * using a view mechanism that is not yet initialize during the parent's construction.
  */
 abstract contract ERC7540DelayRedeem is ERC7540, IERC6372 {
     using SafeCast for uint256;
@@ -36,6 +40,13 @@ abstract contract ERC7540DelayRedeem is ERC7540, IERC6372 {
 
     mapping(address controller => Checkpoints.Trace208) private _redeems;
     mapping(address controller => uint256) private _claimedRedeems;
+
+    /// @dev Triggered if _redeemShareDestination() is not address(0), as this is not supported by this module.
+    error ERC7540DelayInvalidRedeemShareDestination();
+
+    constructor() {
+        require(_redeemShareDestination() == address(0), ERC7540DelayInvalidRedeemShareDestination());
+    }
 
     /// @inheritdoc IERC6372
     function clock() public view virtual returns (uint48) {

--- a/contracts/token/ERC20/extensions/ERC7540DelayRedeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540DelayRedeem.sol
@@ -30,9 +30,9 @@ import {ERC7540} from "./ERC7540.sol";
  * Override {redeemDelay} to customize the waiting period (default: 1 hour) and {clock} to
  * change the time source (default: `block.timestamp`).
  *
- * NOTE: This module does not support temporary share custody through {_redeemShareDestination}. the constructor
- * will try enforce that property, but this check may not be enough if {_redeemShareDestination} is implemented
- * using a view mechanism that is not yet initialize during the parent's construction.
+ * NOTE: This module does not support temporary share custody through {_redeemShareDestination}. The constructor
+ * tries to enforce that property, but the check may be insufficient if {_redeemShareDestination} reads from
+ * storage that is not yet initialized when the parent's constructor runs.
  */
 abstract contract ERC7540DelayRedeem is ERC7540, IERC6372 {
     using SafeCast for uint256;
@@ -41,7 +41,7 @@ abstract contract ERC7540DelayRedeem is ERC7540, IERC6372 {
     mapping(address controller => Checkpoints.Trace208) private _redeems;
     mapping(address controller => uint256) private _claimedRedeems;
 
-    /// @dev Triggered if _redeemShareDestination() is not address(0), as this is not supported by this module.
+    /// @dev Triggered if {_redeemShareDestination} is not address(0), as this is not supported by this module.
     error ERC7540DelayInvalidRedeemShareDestination();
 
     constructor() {

--- a/test/token/ERC20/extensions/ERC7540Delay.test.js
+++ b/test/token/ERC20/extensions/ERC7540Delay.test.js
@@ -31,6 +31,22 @@ describe('ERC7540Delay', function () {
     this.fulfillRedeem = requestId => time.increaseTo.timestamp(requestId);
   });
 
+  describe('sanity', function () {
+    it('construction revert if share origin is not address(0)', async function () {
+      const factory = await ethers.getContractFactory('$ERC7540DelayShareOriginMock');
+      await expect(
+        ethers.deployContract('$ERC7540DelayShareOriginMock', [name, symbol, this.token]),
+      ).to.be.revertedWithCustomError(factory, 'ERC7540DelayInvalidDepositShareOrigin');
+    });
+
+    it('construction revert if share destination is not address(0)', async function () {
+      const factory = await ethers.getContractFactory('$ERC7540DelayShareDestinationMock');
+      await expect(
+        ethers.deployContract('$ERC7540DelayShareDestinationMock', [name, symbol, this.token]),
+      ).to.be.revertedWithCustomError(factory, 'ERC7540DelayInvalidRedeemShareDestination');
+    });
+  });
+
   describe('metadata', function () {
     it('token', async function () {
       await expect(this.mock.asset()).to.eventually.equal(this.token);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment-time validation to ERC7540 delay modules to prevent invalid share origin and destination configurations. Contracts now enforce that certain address mechanisms must resolve to zero, preventing misconfiguration-related issues.

* **Tests**
  * Expanded test coverage to verify validation enforcement during contract deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->