### PR TITLE
ERC7540: add suport for ERC7575 share-to-vault lookup

### DIFF
--- a/contracts/interfaces/IERC7575.sol
+++ b/contracts/interfaces/IERC7575.sol
@@ -5,10 +5,14 @@ pragma solidity >=0.8.4;
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
-/**
- * @dev Multi-Asset ERC-4626 Vaults, as defined in https://eips.ethereum.org/EIPS/eip-7575
- */
+/// @dev Multi-Asset ERC-4626 Vaults, as defined in https://eips.ethereum.org/EIPS/eip-7575
 interface IERC7575 is IERC165, IERC4626 {
-    /// @dev The address of the underlying share received on deposit into the Vault.
+    /// @dev The address of the underlying share received on deposit into the vault.
     function share() external view returns (address shareTokenAddress);
+}
+
+/// @dev Share-to-Vault lookup, as defined in https://eips.ethereum.org/EIPS/eip-7575
+interface IERC7575Share {
+    /// @dev The address of the vault for a specific asset.
+    function vault(address asset) external view returns (address vault);
 }

--- a/contracts/token/ERC20/extensions/ERC7540.sol
+++ b/contracts/token/ERC20/extensions/ERC7540.sol
@@ -10,7 +10,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {LowLevelCall} from "@openzeppelin/contracts/utils/LowLevelCall.sol";
 import {Memory} from "@openzeppelin/contracts/utils/Memory.sol";
 import {IERC7540, IERC7540Operator, IERC7540Deposit, IERC7540Redeem} from "../../../interfaces/IERC7540.sol";
-import {IERC7575} from "../../../interfaces/IERC7575.sol";
+import {IERC7575, IERC7575Share} from "../../../interfaces/IERC7575.sol";
 
 /**
  * @dev Implementation of the ERC-7540 "Asynchronous ERC-4626 Tokenized Vaults" as defined in
@@ -57,7 +57,7 @@ import {IERC7575} from "../../../interfaces/IERC7575.sol";
  * approve operators they fully trust with both their assets and shares.
  * ====
  */
-abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540 {
+abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
     using Math for uint256;
 
     IERC20 private immutable _asset;
@@ -131,6 +131,7 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540 {
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {
         return
             interfaceId == (type(IERC4626).interfaceId ^ type(IERC7575).interfaceId) ||
+            interfaceId == type(IERC7575Share).interfaceId ||
             interfaceId == type(IERC7540Operator).interfaceId ||
             (interfaceId == type(IERC7540Deposit).interfaceId && _isDepositAsync()) ||
             (interfaceId == type(IERC7540Redeem).interfaceId && _isRedeemAsync()) ||
@@ -200,6 +201,11 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540 {
     /// @inheritdoc IERC7575
     function share() public view virtual returns (address) {
         return address(this);
+    }
+
+    /// @inheritdoc IERC7575Share
+    function vault(address asset_) public view virtual returns (address) {
+        return asset_ == asset() ? address(this) : address(0);
     }
 
     /**

--- a/contracts/token/ERC20/extensions/ERC7540.sol
+++ b/contracts/token/ERC20/extensions/ERC7540.sol
@@ -131,7 +131,7 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {
         return
             interfaceId == (type(IERC4626).interfaceId ^ type(IERC7575).interfaceId) ||
-            interfaceId == type(IERC7575Share).interfaceId ||
+            (interfaceId == type(IERC7575Share).interfaceId && share() == address(this)) ||
             interfaceId == type(IERC7540Operator).interfaceId ||
             (interfaceId == type(IERC7540Deposit).interfaceId && _isDepositAsync()) ||
             (interfaceId == type(IERC7540Redeem).interfaceId && _isRedeemAsync()) ||
@@ -205,7 +205,7 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
 
     /// @inheritdoc IERC7575Share
     function vault(address asset_) public view virtual returns (address) {
-        return asset_ == asset() ? address(this) : address(0);
+        return share() == address(this) && asset_ == asset() ? address(this) : address(0);
     }
 
     /**

--- a/contracts/token/ERC20/extensions/ERC7540.sol
+++ b/contracts/token/ERC20/extensions/ERC7540.sol
@@ -130,11 +130,11 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165) returns (bool) {
         return
-            interfaceId == (type(IERC4626).interfaceId ^ type(IERC7575).interfaceId) ||
-            (interfaceId == type(IERC7575Share).interfaceId && share() == address(this)) ||
+            interfaceId == (type(IERC4626).interfaceId ^ type(IERC7575).interfaceId) || // ERC7575
             interfaceId == type(IERC7540Operator).interfaceId ||
             (interfaceId == type(IERC7540Deposit).interfaceId && _isDepositAsync()) ||
             (interfaceId == type(IERC7540Redeem).interfaceId && _isRedeemAsync()) ||
+            (interfaceId == type(IERC7575Share).interfaceId && share() == address(this)) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/test/token/ERC20/extensions/ERC7540Admin.test.js
+++ b/test/token/ERC20/extensions/ERC7540Admin.test.js
@@ -41,6 +41,8 @@ describe('ERC7540Admin', function () {
       describe('metadata', function () {
         it('token', async function () {
           await expect(this.mock.asset()).to.eventually.equal(this.token);
+          await expect(this.mock.vault(this.token)).to.eventually.equal(this.mock);
+          await expect(this.mock.vault(this.mock)).to.eventually.equal(ethers.ZeroAddress);
         });
 
         it('name, symbol, decimals', async function () {

--- a/test/token/ERC20/extensions/ERC7540Delay.test.js
+++ b/test/token/ERC20/extensions/ERC7540Delay.test.js
@@ -34,6 +34,8 @@ describe('ERC7540Delay', function () {
   describe('metadata', function () {
     it('token', async function () {
       await expect(this.mock.asset()).to.eventually.equal(this.token);
+      await expect(this.mock.vault(this.token)).to.eventually.equal(this.mock);
+      await expect(this.mock.vault(this.mock)).to.eventually.equal(ethers.ZeroAddress);
     });
 
     it('name, symbol, decimals', async function () {

--- a/test/token/ERC20/extensions/ERC7575.behavior.js
+++ b/test/token/ERC20/extensions/ERC7575.behavior.js
@@ -29,10 +29,11 @@ function shouldBehaveLikeERC7575({ selfAsset } = {}) {
   selfAsset ??= true;
 
   describe('Should behave like ERC7575', function () {
-    describe('supports ERC-7575 operator interface', function () {
+    describe('supports ERC-7575 interface', function () {
       expect(interfaceId(ERC7575)).to.equal('0x2f0a18c5');
       expect(interfaceId(ERC7575Share)).to.equal('0xf815c03d');
-      shouldSupportInterfaces({ ERC7575 });
+
+      shouldSupportInterfaces(Object.assign({ ERC7575 }, selfAsset ? { ERC7575Share } : {}));
     });
 
     it('get share address', async function () {


### PR DESCRIPTION
Note: this is an optional interface. We can chose to not implement it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced asset-to-vault lookup capability with a new interface standard.
  * ERC7540 now supports vault asset discovery functionality.
  * Enhanced ERC-165 interface detection for better protocol compatibility.

* **Tests**
  * Updated test suite to verify new interface implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->