### PR TITLE
Add ERC-7535 Native Asset Tokenized Vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 12-06-2026
+
+- `IERC7535`: Add interface for ERC-7535 native asset tokenized vaults — the full ERC-4626 surface with `payable` `deposit`/`mint` and the ERC-7528 native-asset placeholder as `asset()`.
+- `ERC7535`: Add base implementation of ERC-7535 with balance-based `totalAssets`, exact-`msg.value` deposit and mint, pre-`msg.value` exchange-rate accounting, the same configurable virtual-offset inflation-attack mitigation as `ERC4626`, checks-effects-interactions withdrawals via `Address.sendValue`, and a reverting (but `virtual`) `receive()` that rejects unsolicited plain transfers.
+
 ## 28-04-2026
 
 - `IERC7540`: Add interface for ERC-7540 asynchronous tokenized vaults, extending ERC-4626 with request-based deposit and redeem flows.

--- a/contracts/interfaces/IERC7535.sol
+++ b/contracts/interfaces/IERC7535.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.2;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+
+/**
+ * @dev Interface of the ERC-7535 "Native Asset ERC-4626 Tokenized Vault", as defined in
+ * https://eips.ethereum.org/EIPS/eip-7535[ERC-7535].
+ *
+ * ERC-7535 is an adaptation of ERC-4626 that uses Ether (or the chain's native EVM asset) as the underlying
+ * asset instead of an ERC-20 token. It reuses the entire ERC-4626 interface and event set; only the
+ * asset-movement semantics and the state mutability of {deposit} and {mint} change.
+ *
+ * NOTE: This interface intentionally does not inherit `IERC4626`. ERC-7535 requires {deposit} and {mint} to
+ * have a `payable` state mutability, which is incompatible with the `nonpayable` definitions in `IERC4626`
+ * (Solidity does not allow a `payable` function to override a `nonpayable` one). All other signatures,
+ * events, and "MUST NOT revert" guarantees mirror `IERC4626`.
+ */
+interface IERC7535 is IERC20, IERC20Metadata {
+    event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
+
+    event Withdraw(
+        address indexed sender,
+        address indexed receiver,
+        address indexed owner,
+        uint256 assets,
+        uint256 shares
+    );
+
+    /**
+     * @dev Returns the address of the underlying token used for the Vault for accounting, depositing, and withdrawing.
+     *
+     * - MUST return `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` per ERC-7528 to represent the native asset.
+     * - MUST NOT revert.
+     */
+    function asset() external view returns (address assetTokenAddress);
+
+    /**
+     * @dev Returns the total amount of the underlying asset that is “managed” by Vault.
+     *
+     * - SHOULD include any compounding that occurs from yield.
+     * - MUST be inclusive of any fees that are charged against assets in the Vault.
+     * - MUST NOT revert.
+     */
+    function totalAssets() external view returns (uint256 totalManagedAssets);
+
+    /**
+     * @dev Returns the amount of shares that the Vault would exchange for the amount of assets provided, in an ideal
+     * scenario where all the conditions are met.
+     *
+     * - MUST NOT be inclusive of any fees that are charged against assets in the Vault.
+     * - MUST NOT show any variations depending on the caller.
+     * - MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
+     * - MUST NOT revert.
+     *
+     * NOTE: This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
+     * “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
+     * from.
+     */
+    function convertToShares(uint256 assets) external view returns (uint256 shares);
+
+    /**
+     * @dev Returns the amount of assets that the Vault would exchange for the amount of shares provided, in an ideal
+     * scenario where all the conditions are met.
+     *
+     * - MUST NOT be inclusive of any fees that are charged against assets in the Vault.
+     * - MUST NOT show any variations depending on the caller.
+     * - MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
+     * - MUST NOT revert.
+     *
+     * NOTE: This calculation MAY NOT reflect the “per-user” price-per-share, and instead should reflect the
+     * “average-user’s” price-per-share, meaning what the average user should expect to see when exchanging to and
+     * from.
+     */
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
+
+    /**
+     * @dev Returns the maximum amount of the underlying asset that can be deposited into the Vault for the receiver,
+     * through a deposit call.
+     *
+     * - MUST return a limited value if receiver is subject to some deposit limit.
+     * - MUST return 2 ** 256 - 1 if there is no limit on the maximum amount of assets that may be deposited.
+     * - MUST NOT revert.
+     */
+    function maxDeposit(address receiver) external view returns (uint256 maxAssets);
+
+    /**
+     * @dev Allows an on-chain or off-chain user to simulate the effects of their deposit at the current block, given
+     * current on-chain conditions.
+     *
+     * - MUST return as close to and no more than the exact amount of Vault shares that would be minted in a deposit
+     *   call in the same transaction. I.e. deposit should return the same or more shares as previewDeposit if called
+     *   in the same transaction.
+     * - MUST NOT account for deposit limits like those returned from maxDeposit and should always act as though the
+     *   deposit would be accepted, regardless if the user has enough tokens approved, etc.
+     * - MUST be inclusive of deposit fees. Integrators should be aware of the existence of deposit fees.
+     * - MUST NOT revert.
+     *
+     * NOTE: any unfavorable discrepancy between convertToShares and previewDeposit SHOULD be considered slippage in
+     * share price or some other type of condition, meaning the depositor will lose assets by depositing.
+     */
+    function previewDeposit(uint256 assets) external view returns (uint256 shares);
+
+    /**
+     * @dev Mints `shares` Vault shares to `receiver` by depositing exactly `msg.value` of the native asset.
+     *
+     * - MUST have a `payable` state mutability.
+     * - MUST use `msg.value` as the primary input parameter for calculating the `shares` output. I.e. MAY ignore the
+     *   `assets` parameter as an input.
+     * - MUST emit the Deposit event.
+     * - MUST revert if all of `msg.value` cannot be deposited (due to deposit limit being reached, slippage, etc).
+     */
+    function deposit(uint256 assets, address receiver) external payable returns (uint256 shares);
+
+    /**
+     * @dev Returns the maximum amount of the Vault shares that can be minted for the receiver, through a mint call.
+     * - MUST return a limited value if receiver is subject to some mint limit.
+     * - MUST return 2 ** 256 - 1 if there is no limit on the maximum amount of shares that may be minted.
+     * - MUST NOT revert.
+     */
+    function maxMint(address receiver) external view returns (uint256 maxShares);
+
+    /**
+     * @dev Allows an on-chain or off-chain user to simulate the effects of their mint at the current block, given
+     * current on-chain conditions.
+     *
+     * - MUST return as close to and no fewer than the exact amount of assets that would be deposited in a mint call
+     *   in the same transaction. I.e. mint should return the same or fewer assets as previewMint if called in the
+     *   same transaction.
+     * - MUST NOT account for mint limits like those returned from maxMint and should always act as though the mint
+     *   would be accepted, regardless if the user has enough tokens approved, etc.
+     * - MUST be inclusive of deposit fees. Integrators should be aware of the existence of deposit fees.
+     * - MUST NOT revert.
+     *
+     * NOTE: any unfavorable discrepancy between convertToAssets and previewMint SHOULD be considered slippage in
+     * share price or some other type of condition, meaning the depositor will lose assets by minting.
+     */
+    function previewMint(uint256 shares) external view returns (uint256 assets);
+
+    /**
+     * @dev Mints exactly `shares` Vault shares to `receiver` by depositing `msg.value` of the native asset.
+     *
+     * - MUST have a `payable` state mutability.
+     * - MUST emit the Deposit event.
+     * - MUST revert if all of `shares` cannot be minted (due to deposit limit being reached, slippage, not enough
+     *   `msg.value` being sent, etc).
+     */
+    function mint(uint256 shares, address receiver) external payable returns (uint256 assets);
+
+    /**
+     * @dev Returns the maximum amount of the underlying asset that can be withdrawn from the owner balance in the
+     * Vault, through a withdraw call.
+     *
+     * - MUST return a limited value if owner is subject to some withdrawal limit or timelock.
+     * - MUST NOT revert.
+     */
+    function maxWithdraw(address owner) external view returns (uint256 maxAssets);
+
+    /**
+     * @dev Allows an on-chain or off-chain user to simulate the effects of their withdrawal at the current block,
+     * given current on-chain conditions.
+     *
+     * - MUST return as close to and no fewer than the exact amount of Vault shares that would be burned in a withdraw
+     *   call in the same transaction. I.e. withdraw should return the same or fewer shares as previewWithdraw if
+     *   called
+     *   in the same transaction.
+     * - MUST NOT account for withdrawal limits like those returned from maxWithdraw and should always act as though
+     *   the withdrawal would be accepted, regardless if the user has enough shares, etc.
+     * - MUST be inclusive of withdrawal fees. Integrators should be aware of the existence of withdrawal fees.
+     * - MUST NOT revert.
+     *
+     * NOTE: any unfavorable discrepancy between convertToShares and previewWithdraw SHOULD be considered slippage in
+     * share price or some other type of condition, meaning the depositor will lose assets by depositing.
+     */
+    function previewWithdraw(uint256 assets) external view returns (uint256 shares);
+
+    /**
+     * @dev Burns shares from owner and sends exactly `assets` of the native asset to receiver.
+     *
+     * - MUST emit the Withdraw event.
+     * - MUST revert if all of assets cannot be withdrawn (due to withdrawal limit being reached, slippage, the owner
+     *   not having enough shares, etc).
+     *
+     * Note that some implementations will require pre-requesting to the Vault before a withdrawal may be performed.
+     * Those methods should be performed separately.
+     */
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256 shares);
+
+    /**
+     * @dev Returns the maximum amount of Vault shares that can be redeemed from the owner balance in the Vault,
+     * through a redeem call.
+     *
+     * - MUST return a limited value if owner is subject to some withdrawal limit or timelock.
+     * - MUST return balanceOf(owner) if owner is not subject to any withdrawal limit or timelock.
+     * - MUST NOT revert.
+     */
+    function maxRedeem(address owner) external view returns (uint256 maxShares);
+
+    /**
+     * @dev Allows an on-chain or off-chain user to simulate the effects of their redemption at the current block,
+     * given current on-chain conditions.
+     *
+     * - MUST return as close to and no more than the exact amount of assets that would be withdrawn in a redeem call
+     *   in the same transaction. I.e. redeem should return the same or more assets as previewRedeem if called in the
+     *   same transaction.
+     * - MUST NOT account for redemption limits like those returned from maxRedeem and should always act as though the
+     *   redemption would be accepted, regardless if the user has enough shares, etc.
+     * - MUST be inclusive of withdrawal fees. Integrators should be aware of the existence of withdrawal fees.
+     * - MUST NOT revert.
+     *
+     * NOTE: any unfavorable discrepancy between convertToAssets and previewRedeem SHOULD be considered slippage in
+     * share price or some other type of condition, meaning the depositor will lose assets by redeeming.
+     */
+    function previewRedeem(uint256 shares) external view returns (uint256 assets);
+
+    /**
+     * @dev Burns exactly shares from owner and sends `assets` of the native asset to receiver.
+     *
+     * - MUST emit the Withdraw event.
+     * - MUST revert if all of shares cannot be redeemed (due to withdrawal limit being reached, slippage, the owner
+     *   not having enough shares, etc).
+     *
+     * NOTE: some implementations will require pre-requesting to the Vault before a withdrawal may be performed.
+     * Those methods should be performed separately.
+     */
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256 assets);
+}

--- a/contracts/interfaces/README.adoc
+++ b/contracts/interfaces/README.adoc
@@ -7,6 +7,7 @@ NOTE: This document is better viewed at https://docs.openzeppelin.com/contracts/
 
 These interfaces are available as `.sol` files. These are useful to interact with third party contracts that implement them.
 
+- {IERC7535}: Native asset (ERC-7535) variant of the ERC-4626 tokenized vault interface, with `payable` deposit and mint.
 - {IERC7540} (`IERC7540Operator`, `IERC7540Deposit`, `IERC7540Redeem`): Operator management and asynchronous deposit/redeem request interfaces for ERC-7540 tokenized vaults.
 - {IERC7575} (`IERC7575`, `IERC7575Share`): Multi-asset ERC-4626 vaults and share-to-vault lookup interfaces.
 - {IERC7786Attributes}: Standard attributes for ERC-7786 cross-chain messaging.
@@ -15,6 +16,8 @@ These interfaces are available as `.sol` files. These are useful to interact wit
 - {IERC7969} (`IDKIMRegistry`): Onchain DKIM public key registry interface for email-based authentication.
 
 == Detailed ABI
+
+{{IERC7535}}
 
 {{IERC7540}}
 

--- a/contracts/mocks/import.sol
+++ b/contracts/mocks/import.sol
@@ -14,6 +14,7 @@ import {
 } from "@openzeppelin/contracts/mocks/account/AccountMock.sol";
 import {ERC1271WalletMock} from "@openzeppelin/contracts/mocks/ERC1271WalletMock.sol";
 import {CallReceiverMock} from "@openzeppelin/contracts/mocks/CallReceiverMock.sol";
+import {EtherReceiverMock} from "@openzeppelin/contracts/mocks/EtherReceiverMock.sol";
 import {ERC7913P256Verifier} from "@openzeppelin/contracts/utils/cryptography/verifiers/ERC7913P256Verifier.sol";
 import {ERC7913RSAVerifier} from "@openzeppelin/contracts/utils/cryptography/verifiers/ERC7913RSAVerifier.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";

--- a/contracts/mocks/token/ERC7535OffsetMock.sol
+++ b/contracts/mocks/token/ERC7535OffsetMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.24;
+
+import {ERC7535} from "../../token/ERC20/extensions/ERC7535.sol";
+
+abstract contract ERC7535OffsetMock is ERC7535 {
+    uint8 private immutable _offset;
+
+    constructor(uint8 offset_) {
+        _offset = offset_;
+    }
+
+    function _decimalsOffset() internal view virtual override returns (uint8) {
+        return _offset;
+    }
+}

--- a/contracts/token/ERC20/extensions/ERC7535.sol
+++ b/contracts/token/ERC20/extensions/ERC7535.sol
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.24;
+
+import {IERC20, IERC20Metadata, ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IERC7535} from "../../../interfaces/IERC7535.sol";
+
+/**
+ * @dev Implementation of the ERC-7535 "Native Asset ERC-4626 Tokenized Vault" as defined in
+ * https://eips.ethereum.org/EIPS/eip-7535[ERC-7535].
+ *
+ * ERC-7535 is an adaptation of ERC-4626 that uses Ether (or the chain's native EVM asset) as the underlying
+ * asset instead of an ERC-20 token. The {asset} placeholder is the ERC-7528 native-asset address
+ * `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`, {totalAssets} is the contract's own Ether balance, and the
+ * native asset enters the Vault as `msg.value` on the `payable` {deposit} and {mint} functions rather than
+ * through an ERC-20 `transferFrom`.
+ *
+ * This extension allows the minting and burning of "shares" (represented using the ERC-20 inheritance) in exchange for
+ * the native asset through standardized {deposit}, {mint}, {redeem} and {burn} workflows. This contract extends the
+ * ERC-20 standard. Any additional extensions included along it would affect the "shares" token represented by this
+ * contract and not the native "asset".
+ *
+ * NOTE: This contract does not inherit `ERC4626`. ERC-7535 requires {deposit} and {mint} to have a `payable`
+ * state mutability, which is incompatible with the `nonpayable` definitions in ERC-4626 (Solidity does not
+ * allow a `payable` function to override a `nonpayable` one). The structure, rounding directions, internal
+ * seams (`_deposit`/`_withdraw`/`_convertToShares`/`_convertToAssets`) and the virtual-offset anti-inflation
+ * math mirror the `ERC4626` implementation of OpenZeppelin Contracts.
+ *
+ * IMPORTANT: A vault backed by a wrapped native asset (such as WETH9) MUST NOT use this contract; per
+ * ERC-7528 and ERC-7535 such a vault is a plain ERC-4626 over the wrapper ERC-20 and MUST report that
+ * wrapper's address from {asset}, not the native-asset placeholder.
+ *
+ * [CAUTION]
+ * ====
+ * In empty (or nearly empty) ERC-7535 vaults, deposits are at high risk of being stolen through frontrunning
+ * with a "donation" to the vault that inflates the price of a share. This is variously known as a donation or inflation
+ * attack and is essentially a problem of slippage. Vault deployers can protect against this attack by making an initial
+ * deposit of a non-trivial amount of the asset, such that price manipulation becomes infeasible. Withdrawals may
+ * similarly be affected by slippage. Users can protect against this attack as well as unexpected slippage in general by
+ * verifying the amount received is as expected, using a wrapper that performs these checks.
+ *
+ * Since {totalAssets} reads `address(this).balance`, the native asset can additionally be force-fed into the Vault
+ * (e.g. through `SELFDESTRUCT` or block-reward payments) without minting shares, bypassing any `receive`/`fallback`
+ * restriction. As in `ERC4626`, this implementation introduces configurable virtual assets and shares to help
+ * developers mitigate that risk. The `_decimalsOffset()` corresponds to an offset in the decimal representation
+ * between the underlying asset's decimals and the vault decimals. This offset also determines the rate of virtual
+ * shares to virtual assets in the vault, which itself determines the initial exchange rate. While not fully preventing
+ * the attack, analysis shows that the default offset (0) makes it non-profitable even if an attacker is able to capture
+ * value from multiple user deposits, as a result of the value being captured by the virtual shares (out of the
+ * attacker's donation) matching the attacker's expected gains. With a larger offset, the attack becomes orders of
+ * magnitude more expensive than it is profitable. More details about the underlying math can be found
+ * https://docs.openzeppelin.com/contracts/5.x/erc4626#inflation-attack[here].
+ *
+ * The drawback of this approach is that the virtual shares do capture (a very small) part of the value being accrued
+ * to the vault. Also, if the vault experiences losses, the users try to exit the vault, the virtual shares and assets
+ * will cause the first user to exit to experience reduced losses in detriment to the last users that will experience
+ * bigger losses. Developers willing to revert back to the pre-virtual-offset behavior just need to override the
+ * `_convertToShares` and `_convertToAssets` functions.
+ * ====
+ *
+ * [NOTE]
+ * ====
+ * When overriding this contract, some elements must be considered:
+ *
+ * * When overriding the behavior of the deposit or withdraw mechanisms, it is recommended to override the internal
+ * functions. Overriding {_deposit} automatically affects both {deposit} and {mint}. Similarly, overriding {_withdraw}
+ * automatically affects both {withdraw} and {redeem}. Overall it is not recommended to override the public facing
+ * functions since that could lead to inconsistent behaviors between the {deposit} and {mint} or between {withdraw} and
+ * {redeem}, which is documented to have led to loss of funds.
+ *
+ * * Overrides to the deposit or withdraw mechanism must be reflected in the preview functions as well.
+ *
+ * * {maxWithdraw} depends on {maxRedeem}. Therefore, overriding {maxRedeem} only is enough. On the other hand,
+ * overriding {maxWithdraw} only would have no effect on {maxRedeem}, and could create an inconsistency between the two
+ * functions.
+ *
+ * * If {previewRedeem} is overridden to revert, {maxWithdraw} must be overridden as necessary to ensure it
+ * always return successfully.
+ * ====
+ */
+abstract contract ERC7535 is ERC20, IERC7535 {
+    using Math for uint256;
+
+    /// @dev The ERC-7528 placeholder address representing the native asset; exposed through {asset}.
+    address private constant NATIVE_ASSET = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /**
+     * @dev Attempted to deposit more assets than the max amount for `receiver`.
+     */
+    error ERC7535ExceededMaxDeposit(address receiver, uint256 assets, uint256 max);
+
+    /**
+     * @dev Attempted to mint more shares than the max amount for `receiver`.
+     */
+    error ERC7535ExceededMaxMint(address receiver, uint256 shares, uint256 max);
+
+    /**
+     * @dev Attempted to withdraw more assets than the max amount for `owner`.
+     */
+    error ERC7535ExceededMaxWithdraw(address owner, uint256 assets, uint256 max);
+
+    /**
+     * @dev Attempted to redeem more shares than the max amount for `owner`.
+     */
+    error ERC7535ExceededMaxRedeem(address owner, uint256 shares, uint256 max);
+
+    /**
+     * @dev Attempted to {deposit} with a `msg.value` that does not match the `assets` argument.
+     */
+    error ERC7535UnexpectedDepositValue(uint256 value, uint256 assets);
+
+    /**
+     * @dev Attempted to {mint} with a `msg.value` that does not match the cost of the requested `shares`.
+     */
+    error ERC7535UnexpectedMintValue(uint256 value, uint256 cost);
+
+    /**
+     * @dev Reverts on a plain native-asset transfer to the vault — value enters only via {deposit} or {mint}.
+     */
+    error ERC7535UnsolicitedDeposit();
+
+    /**
+     * @dev Decimals are computed by adding the decimal offset on top of the native asset's decimals, which are fixed
+     * at 18 (the native asset has no `decimals()` to query).
+     *
+     * See {IERC20Metadata-decimals}.
+     */
+    function decimals() public view virtual override(IERC20Metadata, ERC20) returns (uint8) {
+        return 18 + _decimalsOffset();
+    }
+
+    /// @inheritdoc IERC7535
+    function asset() public view virtual returns (address) {
+        return NATIVE_ASSET;
+    }
+
+    /// @inheritdoc IERC7535
+    function totalAssets() public view virtual returns (uint256) {
+        return address(this).balance;
+    }
+
+    /// @inheritdoc IERC7535
+    function convertToShares(uint256 assets) public view virtual returns (uint256) {
+        return _convertToShares(assets, Math.Rounding.Floor);
+    }
+
+    /// @inheritdoc IERC7535
+    function convertToAssets(uint256 shares) public view virtual returns (uint256) {
+        return _convertToAssets(shares, Math.Rounding.Floor);
+    }
+
+    /// @inheritdoc IERC7535
+    function maxDeposit(address) public view virtual returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @inheritdoc IERC7535
+    function maxMint(address) public view virtual returns (uint256) {
+        return type(uint256).max;
+    }
+
+    /// @inheritdoc IERC7535
+    function maxWithdraw(address owner) public view virtual returns (uint256) {
+        return previewRedeem(maxRedeem(owner));
+    }
+
+    /// @inheritdoc IERC7535
+    function maxRedeem(address owner) public view virtual returns (uint256) {
+        return balanceOf(owner);
+    }
+
+    /// @inheritdoc IERC7535
+    function previewDeposit(uint256 assets) public view virtual returns (uint256) {
+        return _convertToShares(assets, Math.Rounding.Floor);
+    }
+
+    /// @inheritdoc IERC7535
+    function previewMint(uint256 shares) public view virtual returns (uint256) {
+        return _convertToAssets(shares, Math.Rounding.Ceil);
+    }
+
+    /// @inheritdoc IERC7535
+    function previewWithdraw(uint256 assets) public view virtual returns (uint256) {
+        return _convertToShares(assets, Math.Rounding.Ceil);
+    }
+
+    /// @inheritdoc IERC7535
+    function previewRedeem(uint256 shares) public view virtual returns (uint256) {
+        return _convertToAssets(shares, Math.Rounding.Floor);
+    }
+
+    /// @inheritdoc IERC7535
+    function deposit(uint256 assets, address receiver) public payable virtual returns (uint256) {
+        if (msg.value != assets) {
+            revert ERC7535UnexpectedDepositValue(msg.value, assets);
+        }
+
+        uint256 maxAssets = maxDeposit(receiver);
+        if (assets > maxAssets) {
+            revert ERC7535ExceededMaxDeposit(receiver, assets, maxAssets);
+        }
+
+        uint256 shares = _convertToShares(assets, Math.Rounding.Floor);
+        _deposit(_msgSender(), receiver, assets, shares);
+
+        return shares;
+    }
+
+    /// @inheritdoc IERC7535
+    function mint(uint256 shares, address receiver) public payable virtual returns (uint256) {
+        uint256 maxShares = maxMint(receiver);
+        if (shares > maxShares) {
+            revert ERC7535ExceededMaxMint(receiver, shares, maxShares);
+        }
+
+        uint256 assets = _convertToAssets(shares, Math.Rounding.Ceil);
+        if (msg.value != assets) {
+            revert ERC7535UnexpectedMintValue(msg.value, assets);
+        }
+
+        _deposit(_msgSender(), receiver, assets, shares);
+
+        return assets;
+    }
+
+    /// @inheritdoc IERC7535
+    function withdraw(uint256 assets, address receiver, address owner) public virtual returns (uint256) {
+        uint256 maxAssets = maxWithdraw(owner);
+        if (assets > maxAssets) {
+            revert ERC7535ExceededMaxWithdraw(owner, assets, maxAssets);
+        }
+
+        uint256 shares = previewWithdraw(assets);
+        _withdraw(_msgSender(), receiver, owner, assets, shares);
+
+        return shares;
+    }
+
+    /// @inheritdoc IERC7535
+    function redeem(uint256 shares, address receiver, address owner) public virtual returns (uint256) {
+        uint256 maxShares = maxRedeem(owner);
+        if (shares > maxShares) {
+            revert ERC7535ExceededMaxRedeem(owner, shares, maxShares);
+        }
+
+        uint256 assets = previewRedeem(shares);
+        _withdraw(_msgSender(), receiver, owner, assets, shares);
+
+        return assets;
+    }
+
+    /**
+     * @dev Internal conversion function (from assets to shares) with support for rounding direction.
+     */
+    function _convertToShares(uint256 assets, Math.Rounding rounding) internal view virtual returns (uint256) {
+        return assets.mulDiv(totalSupply() + 10 ** _decimalsOffset(), _pretotalAssets() + 1, rounding);
+    }
+
+    /**
+     * @dev Internal conversion function (from shares to assets) with support for rounding direction.
+     */
+    function _convertToAssets(uint256 shares, Math.Rounding rounding) internal view virtual returns (uint256) {
+        return shares.mulDiv(_pretotalAssets() + 1, totalSupply() + 10 ** _decimalsOffset(), rounding);
+    }
+
+    /**
+     * @dev Returns the pre-call value of {totalAssets} the share math is priced against — i.e. the contract's
+     * balance excluding any in-flight `msg.value` from the current `payable` call. In any non-`payable` context
+     * `msg.value` is `0` and the result equals {totalAssets}; in {deposit}/{mint} the subtraction yields the
+     * pre-call balance. Overrides MUST return a value less than or equal to {totalAssets} and MUST be the only
+     * `totalAssets`-like value referenced by {_convertToShares}/{_convertToAssets}.
+     */
+    function _pretotalAssets() internal view virtual returns (uint256) {
+        return totalAssets() - msg.value;
+    }
+
+    /**
+     * @dev Deposit/mint common workflow. {_transferIn} is a no-op by default since the native asset has already
+     * been received as `msg.value`; the hook exists for parity with `ERC4626` so overrides can mirror that shape.
+     */
+    function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal virtual {
+        _transferIn(caller, assets);
+        _mint(receiver, shares);
+
+        emit Deposit(caller, receiver, assets, shares);
+    }
+
+    /**
+     * @dev Withdraw/redeem common workflow. Spends the allowance and burns the shares BEFORE sending the native
+     * asset out: a reentrant call from the receiver observes an already-reduced share state. Overrides MUST
+     * preserve this ordering.
+     */
+    function _withdraw(
+        address caller,
+        address receiver,
+        address owner,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual {
+        if (caller != owner) {
+            _spendAllowance(owner, caller, shares);
+        }
+
+        _burn(owner, shares);
+        _transferOut(receiver, assets);
+
+        emit Withdraw(caller, receiver, owner, assets, shares);
+    }
+
+    /// @dev Hook for transferring the native asset *into* the vault. No-op by default: value has already been
+    /// received as `msg.value`. Provided for symmetry with `ERC4626._transferIn`. Used by {_deposit}.
+    function _transferIn(address /* from */, uint256 /* assets */) internal virtual {}
+
+    /// @dev Performs a transfer out of the native asset. The default implementation uses `Address.sendValue`,
+    /// which forwards all remaining gas. Used by {_withdraw}.
+    function _transferOut(address to, uint256 assets) internal virtual {
+        Address.sendValue(payable(to), assets);
+    }
+
+    /// @dev Overrides MUST keep `offset <= 77`: the conversion math computes `10 ** offset`, which overflows
+    /// `uint256` for any larger value and would make every deposit, mint, preview and conversion revert with an
+    /// arithmetic panic. (The `uint8` range of {decimals} allows up to `237`, but the conversion arithmetic is
+    /// the binding constraint.)
+    function _decimalsOffset() internal view virtual returns (uint8) {
+        return 0;
+    }
+
+    /// @dev Reverts on plain native-asset transfers; value must enter via {deposit} or {mint}. Note that this
+    /// does not stop protocol-level force-feeds (e.g. `SELFDESTRUCT` or block-reward payments), which bypass
+    /// `receive` entirely — see the inflation-attack considerations above.
+    receive() external payable virtual {
+        revert ERC7535UnsolicitedDeposit();
+    }
+}

--- a/contracts/token/README.adoc
+++ b/contracts/token/README.adoc
@@ -14,6 +14,7 @@ Set of extensions and utilities for tokens (e.g ERC-20, ERC-721, ERC-1155) and d
  * {ERC20Restricted}: Extension of ERC20 that allows implementing user account transfer restrictions (blocklist or allowlist) inspired by EIP-7943.
  * {ERC20uRWA}: Extension of ERC20 according to EIP-7943, combining standard ERC-20 with RWA-specific features like account restrictions, asset freezing, and forced transfers.
  * {ERC4626Fees}: ERC4626 vault with fees on entry (deposit/mint) or exit (withdraw/redeem).
+ * {ERC7535}: Implementation of ERC-7535 "Native Asset ERC-4626 Tokenized Vault", using the chain's native asset (e.g. Ether) as the underlying asset instead of an ERC-20 token.
  * {ERC7540}: Implementation of ERC-7540 "Asynchronous ERC-4626 Tokenized Vaults", providing a base for vaults with asynchronous deposit and/or redemption flows.
  * {ERC7540AdminDeposit}: Admin-controlled (operator-triggered) fulfillment strategy for asynchronous deposits in ERC-7540 vaults.
  * {ERC7540AdminRedeem}: Admin-controlled (operator-triggered) fulfillment strategy for asynchronous redemptions in ERC-7540 vaults.
@@ -43,6 +44,10 @@ Set of extensions and utilities for tokens (e.g ERC-20, ERC-721, ERC-1155) and d
 {{ERC20uRWA}}
 
 {{ERC4626Fees}}
+
+== ERC7535
+
+{{ERC7535}}
 
 == ERC7540
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -4,6 +4,7 @@
 *** xref:account-modules.adoc[Modules]
 ** xref:paymasters.adoc[Paymasters]
 * xref:contracts::tokens.adoc[Tokens]
+** xref:erc7535.adoc[ERC-7535]
 ** xref:erc7540.adoc[ERC-7540]
 * xref:crosschain.adoc[Crosschain]
 * xref:utilities.adoc[Utilities]

--- a/docs/modules/ROOT/pages/erc7535.adoc
+++ b/docs/modules/ROOT/pages/erc7535.adoc
@@ -1,0 +1,83 @@
+= ERC-7535
+
+https://eips.ethereum.org/EIPS/eip-7535[ERC-7535] is an adaptation of xref:contracts::erc4626.adoc[ERC-4626] in which the underlying asset of the vault is the chain's native asset (e.g. Ether) instead of an ERC-20 token. It keeps the ERC-4626 share-accounting model, rounding rules, and interface, so the same mental model, security considerations, and customizations apply, with a few native-asset specific differences.
+
+We provide a base implementation, `ERC7535`, that mirrors the `ERC4626` implementation in `@openzeppelin/contracts` — including the configurable virtual shares and assets used to mitigate the xref:contracts::erc4626.adoc#inflation-attack[inflation attack].
+
+== Differences with ERC-4626
+
+`ERC7535` behaves like `ERC4626`, with the following changes:
+
+* `asset()` returns the placeholder address `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` defined by https://eips.ethereum.org/EIPS/eip-7528[ERC-7528], and the vault uses 18 decimals (those of the native asset) as its base before applying the optional decimals offset.
+* `deposit` and `mint` are `payable`. The native asset is provided as `msg.value` instead of being pulled with an ERC-20 `transferFrom`, so there is no allowance flow for the underlying asset. `deposit(assets, receiver)` requires `msg.value == assets`; `mint(shares, receiver)` requires `msg.value` to equal the previewed cost exactly (mirroring how `ERC4626.mint` pulls exactly `previewMint(shares)`), reverting otherwise.
+* Withdrawals and redemptions send the native asset out with a low-level `call` (xref:contracts::api:utils.adoc#Address-sendValue-address-payable-uint256-[`Address.sendValue`]) instead of an ERC-20 `transfer`.
+
+[source,solidity]
+----
+contract NativeVault is ERC7535 {
+    constructor() ERC20("Native Vault", "nvETH") {}
+}
+----
+
+To raise the resistance to the inflation attack, override `_decimalsOffset()`. A non-zero offset multiplies the virtual-shares term in the conversion formula, making a force-feed donation orders of magnitude more expensive than profitable (the trade-off is that a tiny portion of every yield accrual is captured by the virtual shares — see xref:#inflation-attack[Inflation attack]):
+
+[source,solidity]
+----
+contract HardenedNativeVault is ERC7535 {
+    constructor() ERC20("Hardened Native Vault", "hnvETH") {}
+
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return 6;
+    }
+}
+----
+
+[TIP]
+====
+Prefer `deposit(assets, receiver)` over `mint(shares, receiver)` for an ETH-in flow. `mint` requires `msg.value` to equal `previewMint(shares)` *exactly*, and that previewed cost can change between the off-chain quote and the on-chain transaction (any donation, yield accrual, or other deposit in the same block shifts the rate). `deposit` lets the caller pin the wei they pay, so a same-block rate move at worst changes how many shares they get — not whether the call succeeds. (`mint` is the right choice when an integrator needs an exact share count and is OK with the call reverting if the rate has moved.)
+====
+
+IMPORTANT: A vault backed by a wrapped native asset (such as WETH9) MUST NOT use this contract. Per ERC-7528 and ERC-7535 such a vault is a plain xref:contracts::erc4626.adoc[ERC-4626] over the wrapper ERC-20 and must report that wrapper's address from `asset()`.
+
+== Accounting and `msg.value`
+
+`totalAssets()` returns `address(this).balance`. Because `deposit` and `mint` are `payable`, the deposited `msg.value` is already part of that balance when the exchange rate is computed — unlike an ERC-4626 vault, where the assets are only pulled in *after* the share amount is computed from the pre-deposit balance.
+
+To keep the behavior identical, `ERC7535` computes the exchange rate inside `deposit`/`mint` against `totalAssets() - msg.value` (the pre-call balance), while all preview and conversion functions use `totalAssets()` directly. As a result, a standalone `previewDeposit(assets)` returns exactly the number of shares a subsequent `deposit` of `assets` mints. The adjustment is applied at the `payable` call sites because `msg.value` cannot be read from a `view` function such as `totalAssets`.
+
+[[inflation-attack]]
+== Security concern: Inflation attack
+
+Native asset vaults are exposed to the same xref:contracts::erc4626.adoc#inflation-attack[donation / inflation attack] as ERC-4626 vaults, and `ERC7535` uses the same mitigation: configurable virtual shares and assets parameterized by `_decimalsOffset()`. The default offset of `0` makes the attack non-profitable, and a larger offset makes it orders of magnitude more expensive than profitable.
+
+Note that a native asset vault cannot keep its balance strictly equal to the sum of deposits: it can always be force-fed extra native asset, for example by being a block's `coinbase` or through the `SELFDESTRUCT` opcode. `totalAssets()` is balance-based and therefore tracks such donations, exactly like a direct ERC-20 transfer would for an ERC-4626 vault; the virtual-offset mitigation — not internal balance accounting — is the defense.
+
+== Security concern: Reentrancy
+
+Sending the native asset out uses a low-level `call` via xref:contracts::api:utils.adoc#Address-sendValue-address-payable-uint256-[`Address.sendValue`], which forwards all remaining gas. The full-gas forward is deliberate: it keeps the vault compatible with smart-contract receivers (multisigs, account-abstraction wallets, proxies) whose `receive()` typically costs more than the spec's suggested 2300-gas stipend. The reentrancy risk that the full-gas forward opens is handled by the checks-effects-interactions pattern: on withdrawals and redemptions the shares are burned *before* the value is sent, so a reentrant call from the receiver observes a consistent, already-reduced share price. As in `ERC4626`, reentrancy safety relies on this ordering rather than on a reentrancy guard. Integrators adding custom logic to `_deposit`/`_withdraw` should preserve this ordering, or add an explicit reentrancy guard.
+
+== Plain native-asset transfers
+
+Value must enter the vault through the standardized `deposit` or `mint` entry points so it is matched with newly issued shares. To make accidental misuse fail loudly, `ERC7535` implements a `receive()` function that reverts with the named error `ERC7535UnsolicitedDeposit`: plain `.transfer`, `.send` or `call{value: x}("")` to the vault revert with a reason wallets and UIs can decode, instead of being silently absorbed as a donation that would skew the next deposit's exchange rate.
+
+The `receive()` function is `virtual`. An integrator whose vault must accept plain native-asset payments — for example a rewards distributor that pays the vault periodically on a chain without beacon-layer withdrawals — can override it to admit a known sender, accepting that such payments raise the share price for existing holders exactly like a donation (often the intended effect for yield distribution).
+
+Note that this guard cannot stop the protocol-level force-feeds: native asset routed through `SELFDESTRUCT` or paid out as block-reward / `coinbase` tips bypasses `receive()` entirely and lands on `address(this).balance`. Because `totalAssets()` is balance-based, such donations are tracked exactly as a direct ERC-20 transfer would be for an ERC-4626 vault; the defense is the same virtual-offset math described in xref:#inflation-attack[Security concern: Inflation attack], not the `receive` revert.
+
+== Exact `msg.value` requirement
+
+`deposit(assets, receiver)` requires `msg.value == assets` and `mint(shares, receiver)` requires `msg.value == previewMint(shares)` exactly; there is no refund path. ERC-7535 says `deposit` MAY ignore the `assets` argument, but ignoring it lets a buggy integrator silently desync the amount they meant to send from the amount they actually paid, with no way to detect it on-chain. Requiring strict equality surfaces the desync immediately as a typed revert (`ERC7535UnexpectedDepositValue` / `ERC7535UnexpectedMintValue`) and keeps the emitted `Deposit` event provably consistent with the wei that entered the vault.
+
+== Override checklist
+
+When customizing `ERC7535`, keep the following invariants in mind in addition to the inherited ERC-4626 ones:
+
+* `_pretotalAssets()` MUST return a value less than or equal to `totalAssets()` in every context. Overstating it inflates the share price during `deposit`/`mint`; understating it during a `view` call misprices the public previews.
+* Custom `_convertToShares`/`_convertToAssets` MUST source the "total assets" value from `_pretotalAssets()` (not `totalAssets()` or `msg.value` directly). Otherwise the in-flight `msg.value` is re-mixed into the rate.
+* `totalAssets()` MUST NOT revert. When sourcing the total from an external oracle, wrap the call in `try/catch` and return a safe fallback. Overstating `totalAssets()` will make `withdraw`/`redeem` attempt to send more than `address(this).balance` and revert in `Address.sendValue`, locking exits until the balance catches up with the reported total.
+* `_deposit` overrides MUST NOT introduce an outbound native-asset call (e.g. a refund of "excess" `msg.value`) before `_mint`: that reopens the reentrancy / refund-griefing class this design avoids by requiring an exact `msg.value`.
+* `_withdraw` overrides MUST preserve the checks-effects-interactions ordering (allowance spent and shares burned BEFORE the outbound transfer).
+* `_decimalsOffset()` overrides MUST keep `offset <= 77`. The conversion math computes `10 ** offset`, which overflows `uint256` from `offset >= 78` onwards: the vault would deploy but every deposit, mint, preview and conversion would revert with an arithmetic panic. (The `uint8` range of `decimals()` alone would allow up to `237`, but the conversion arithmetic is the binding constraint.)
+* `maxDeposit` / `maxMint` overrides must stay consistent with any override of `previewDeposit` / `previewMint`, symmetric to the `maxWithdraw` / `maxRedeem` consistency noted in the contract NatSpec.
+
+Off-chain previews must be performed *before* sending value, since the public `view` functions cannot account for an in-flight `msg.value`.

--- a/test/token/ERC20/extensions/ERC7535.t.sol
+++ b/test/token/ERC20/extensions/ERC7535.t.sol
@@ -1,0 +1,649 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC7535} from "@openzeppelin/community-contracts/token/ERC20/extensions/ERC7535.sol";
+
+/// @dev Concrete deployable ERC7535 vault with a configurable decimals offset.
+contract ERC7535VaultMock is ERC7535 {
+    uint8 private immutable _offset;
+
+    constructor(uint8 offset_) ERC20("Native Vault", "nVLT") {
+        _offset = offset_;
+    }
+
+    function _decimalsOffset() internal view virtual override returns (uint8) {
+        return _offset;
+    }
+}
+
+/// @dev Malicious share owner / receiver that attempts to reenter the vault on the ETH `sendValue` callback.
+///
+/// With the CEI-only design (no reentrancy guard), the reentrant call is NOT itself blocked by a guard. Instead
+/// this receiver is used to observe the vault's state *during* the outbound ETH push and to attempt a second,
+/// full-amount redeem of the very shares that triggered the payout. The point of the tests is to prove that
+/// checks-effects-interactions makes such a reentry harmless: the shares are already burned when the callback
+/// fires, so the receiver cannot extract more than its shares entitled it to, and cannot drain other users.
+contract ReentrantReceiver {
+    enum Kind {
+        None,
+        Withdraw,
+        Redeem
+    }
+
+    ERC7535VaultMock public vault;
+    Kind public kind;
+    uint256 public reenterShares; // shares the receiver tries to re-redeem during the callback
+
+    bool public reentered;
+    bool public reentryReverted;
+
+    // State snapshot observed *inside* the reentrant callback (i.e. mid-`_withdraw`, after the burn).
+    uint256 public observedSelfBalance;
+    uint256 public observedTotalSupply;
+
+    function setup(ERC7535VaultMock vault_, Kind kind_, uint256 reenterShares_) external {
+        vault = vault_;
+        kind = kind_;
+        reenterShares = reenterShares_;
+    }
+
+    receive() external payable {
+        if (kind == Kind.None) return;
+        reentered = true;
+
+        // Observe the vault state as seen by a reentrant party during the ETH push.
+        observedSelfBalance = vault.balanceOf(address(this));
+        observedTotalSupply = vault.totalSupply();
+
+        // Attempt to re-extract the *same* shares again, mid-payout. CEI must make this fail (the shares were
+        // already burned) or otherwise be unable to over-drain. We swallow the revert so the outer call can
+        // complete and the test can assert the resulting accounting.
+        try this.reenter() {
+            reentryReverted = false;
+        } catch {
+            reentryReverted = true;
+        }
+    }
+
+    function reenter() external {
+        if (kind == Kind.Withdraw) {
+            vault.withdraw(reenterShares, address(this), address(this));
+        } else if (kind == Kind.Redeem) {
+            vault.redeem(reenterShares, address(this), address(this));
+        }
+    }
+}
+
+contract ERC7535Test is Test {
+    uint256 internal constant MAX_ETH = 1e27; // ~1B ETH worth of wei, keeps fuzz inputs realistic
+
+    ERC7535VaultMock internal vault;
+
+    address internal attacker = makeAddr("attacker");
+    address internal victim = makeAddr("victim");
+    address internal other = makeAddr("other");
+
+    receive() external payable {}
+
+    function setUp() public {
+        vault = new ERC7535VaultMock(0);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata / asset semantics
+    // --------------------------------------------------------------------------------------------
+
+    function testAssetSentinel() public view {
+        assertEq(vault.asset(), 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+    }
+
+    function testFuzzDecimals(uint8 offset) public {
+        // Bound across the full uint8 range so the fuzzer also exercises the documented overflow at
+        // 18 + offset > 255 (i.e. offset >= 238), mirroring the ERC4626 decimals overflow assertion.
+        offset = uint8(bound(offset, 0, 255));
+        ERC7535VaultMock v = new ERC7535VaultMock(offset);
+        if (uint256(18) + uint256(offset) > type(uint8).max) {
+            // 0x11 is the Panic code for arithmetic over/underflow.
+            vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+            v.decimals();
+        } else {
+            assertEq(v.decimals(), uint256(18) + offset);
+        }
+    }
+
+    function testTotalAssetsTracksBalance() public {
+        assertEq(vault.totalAssets(), 0);
+        vm.deal(address(vault), 5 ether);
+        assertEq(vault.totalAssets(), 5 ether);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Decimals offset arithmetic ceiling: 10 ** offset overflows uint256 from offset 78 onwards,
+    // which is the binding constraint documented on `_decimalsOffset` (tighter than the uint8
+    // ceiling of 237 on `decimals()`).
+    // --------------------------------------------------------------------------------------------
+
+    function testOffset77IsTheLargestWorkingOffset() public {
+        ERC7535VaultMock v = new ERC7535VaultMock(77);
+
+        assertEq(v.decimals(), 18 + 77);
+        assertEq(v.previewDeposit(1), 10 ** 77);
+
+        vm.deal(address(this), 1);
+        uint256 minted = v.deposit{value: 1}(1, address(this));
+        assertEq(minted, 10 ** 77);
+    }
+
+    function testOffset78BricksConversionsWithArithmeticPanic() public {
+        // Deploys fine — the failure only surfaces on the first conversion-dependent call.
+        ERC7535VaultMock v = new ERC7535VaultMock(78);
+
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        v.previewDeposit(1);
+
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        v.previewMint(1);
+
+        vm.deal(address(this), 1);
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        v.deposit{value: 1}(1, address(this));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // msg.value enforcement
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzDepositRevertsOnValueMismatch(uint256 assets, uint256 value) public {
+        assets = bound(assets, 0, MAX_ETH);
+        value = bound(value, 0, MAX_ETH);
+        vm.assume(assets != value);
+        vm.deal(address(this), value);
+        vm.expectRevert(abi.encodeWithSelector(ERC7535.ERC7535UnexpectedDepositValue.selector, value, assets));
+        vault.deposit{value: value}(assets, victim);
+    }
+
+    function testFuzzMintRevertsOnValueMismatch(uint256 shares, uint256 value) public {
+        shares = bound(shares, 1, MAX_ETH);
+        uint256 cost = vault.previewMint(shares); // empty vault, queried before sending value
+        value = bound(value, 0, MAX_ETH);
+        vm.assume(value != cost);
+        vm.deal(address(this), value);
+        vm.expectRevert(abi.encodeWithSelector(ERC7535.ERC7535UnexpectedMintValue.selector, value, cost));
+        vault.mint{value: value}(shares, victim);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // previewDeposit (queried standalone, before value is sent) == shares actually minted
+    // This is the msg.value / totalAssets correctness property.
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzPreviewDepositEqualsMinted(uint256 seed, uint256 assets) public {
+        // Seed the vault with some real balance and supply so totalAssets() and totalSupply() are non-trivial.
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        assets = bound(assets, 0, MAX_ETH);
+
+        // Off-chain preview MUST be computed before sending value (view cannot see in-flight msg.value).
+        uint256 previewed = vault.previewDeposit(assets);
+
+        vm.deal(attacker, assets);
+        vm.prank(attacker);
+        uint256 minted = vault.deposit{value: assets}(assets, attacker);
+
+        assertEq(minted, previewed, "previewDeposit != minted shares");
+        assertEq(vault.balanceOf(attacker), previewed);
+    }
+
+    function testFuzzPreviewMintEqualsActualCost(uint256 seed, uint256 shares) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        shares = bound(shares, 0, 1e24);
+        uint256 cost = vault.previewMint(shares);
+        vm.assume(cost <= MAX_ETH);
+
+        vm.deal(attacker, cost);
+        vm.prank(attacker);
+        uint256 actual = vault.mint{value: cost}(shares, attacker);
+
+        assertEq(actual, cost, "mint returned assets != previewMint");
+        assertEq(vault.balanceOf(attacker), shares);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Inflation / donation attack non-profitability at offset 0 (force-feed via vm.deal)
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzInflationAttackNotProfitable(uint256 donation, uint256 victimDeposit) public {
+        // Offset-0 vault (default), fresh from setUp.
+        donation = bound(donation, 0, MAX_ETH);
+        victimDeposit = bound(victimDeposit, 1, MAX_ETH);
+
+        // 1. Attacker makes the canonical 1 wei first deposit.
+        vm.deal(attacker, 1);
+        vm.prank(attacker);
+        vault.deposit{value: 1}(1, attacker);
+        uint256 attackerShares = vault.balanceOf(attacker);
+
+        // 2. Attacker force-feeds a donation directly into the vault balance (SELFDESTRUCT/coinbase analogue).
+        vm.deal(address(vault), address(vault).balance + donation);
+        uint256 attackerSpent = 1 + donation;
+
+        // 3. Victim deposits.
+        vm.deal(victim, victimDeposit);
+        vm.prank(victim);
+        vault.deposit{value: victimDeposit}(victimDeposit, victim);
+
+        // 4. Attacker redeems everything they hold.
+        uint256 attackerPayout = vault.previewRedeem(attackerShares);
+
+        // Property: at offset 0 the attacker can never come out ahead of what they put in.
+        assertLe(attackerPayout, attackerSpent, "inflation attack was profitable at offset 0");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Round-trips: a user never extracts more than they put in.
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzDepositRedeemRoundTrip(uint256 seed, uint256 assets) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        assets = bound(assets, 0, MAX_ETH);
+        vm.deal(victim, assets);
+        vm.prank(victim);
+        uint256 shares = vault.deposit{value: assets}(assets, victim);
+
+        vm.prank(victim);
+        uint256 redeemed = vault.redeem(shares, victim, victim);
+
+        assertLe(redeemed, assets, "deposit->redeem extracted more than deposited");
+    }
+
+    function testFuzzMintRedeemRoundTrip(uint256 seed, uint256 shares) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        shares = bound(shares, 0, 1e24);
+        uint256 cost = vault.previewMint(shares);
+        vm.assume(cost <= MAX_ETH);
+
+        vm.deal(victim, cost);
+        vm.prank(victim);
+        vault.mint{value: cost}(shares, victim);
+
+        vm.prank(victim);
+        uint256 redeemed = vault.redeem(shares, victim, victim);
+
+        assertLe(redeemed, cost, "mint->redeem extracted more than paid");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // convertToShares ∘ convertToAssets is a contraction (rounding favors the vault).
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzConvertRoundTripContraction(uint256 seed, uint256 shares) public {
+        seed = bound(seed, 0, MAX_ETH);
+        if (seed != 0) {
+            vm.deal(address(this), seed);
+            vault.deposit{value: seed}(seed, other);
+        }
+
+        shares = bound(shares, 0, vault.totalSupply() == 0 ? MAX_ETH : vault.totalSupply());
+
+        uint256 assets = vault.convertToAssets(shares);
+        uint256 backToShares = vault.convertToShares(assets);
+
+        assertLe(backToShares, shares, "convertToShares(convertToAssets(s)) > s: rounding favored user");
+    }
+
+    function testFuzzConvertAssetsRoundTripContraction(uint256 seed, uint256 assets) public {
+        seed = bound(seed, 1, MAX_ETH);
+        vm.deal(address(this), seed);
+        vault.deposit{value: seed}(seed, other);
+
+        assets = bound(assets, 0, MAX_ETH);
+
+        uint256 shares = vault.convertToShares(assets);
+        uint256 backToAssets = vault.convertToAssets(shares);
+
+        assertLe(backToAssets, assets, "convertToAssets(convertToShares(a)) > a: rounding favored user");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Force-fed ETH does not break accounting (view functions still answer, withdraw still works).
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzForceFedEthDoesNotBreakAccounting(uint256 deposit, uint256 forceFed) public {
+        deposit = bound(deposit, 1, MAX_ETH);
+        forceFed = bound(forceFed, 0, MAX_ETH);
+
+        vm.deal(victim, deposit);
+        vm.prank(victim);
+        uint256 shares = vault.deposit{value: deposit}(deposit, victim);
+
+        // Force-feed extra ETH that mints no shares.
+        vm.deal(address(vault), address(vault).balance + forceFed);
+
+        assertEq(vault.totalAssets(), deposit + forceFed);
+        // totalSupply unaffected by the donation.
+        assertEq(vault.totalSupply(), shares);
+
+        // Victim can still redeem; payout is well-defined and never reverts.
+        uint256 expected = vault.previewRedeem(shares);
+        vm.prank(victim);
+        uint256 redeemed = vault.redeem(shares, victim, victim);
+        assertEq(redeemed, expected);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Reentrancy (CEI-only, no guard): a malicious receiver that reenters withdraw/redeem during the
+    // ETH `sendValue` push MAY or MAY NOT revert on its own, but MUST NOT (a) extract more native asset
+    // than its shares entitle it to, or (b) drain other users' funds. Because `_withdraw` follows
+    // checks-effects-interactions (allowance spent and shares burned BEFORE the ETH send), the reentrant
+    // call observes an already-reduced state and any second extraction of the same shares is impossible.
+    // --------------------------------------------------------------------------------------------
+
+    function _fundReceiver(ReentrantReceiver r, uint256 deposit) internal returns (uint256 shares) {
+        vm.deal(address(r), deposit);
+        vm.prank(address(r));
+        shares = vault.deposit{value: deposit}(deposit, address(r));
+    }
+
+    /// @dev Asserts the CEI invariants for a redeem whose payout reenters the vault.
+    function _assertReentrancyCEI(ReentrantReceiver.Kind kind) internal {
+        ReentrantReceiver r = new ReentrantReceiver();
+
+        // Seed a second, honest depositor so the vault holds extra ETH the attacker could try to steal.
+        uint256 otherDeposit = 10 ether;
+        vm.deal(other, otherDeposit);
+        vm.prank(other);
+        uint256 otherShares = vault.deposit{value: otherDeposit}(otherDeposit, other);
+
+        // Attacker becomes a share owner.
+        uint256 attackerDeposit = 5 ether;
+        uint256 attackerShares = _fundReceiver(r, attackerDeposit);
+
+        // The attacker will try to re-redeem its FULL share balance again during the payout callback.
+        r.setup(vault, kind, attackerShares);
+
+        uint256 vaultBalBefore = address(vault).balance;
+        uint256 totalSupplyBefore = vault.totalSupply();
+        uint256 expectedPayout = vault.previewRedeem(attackerShares);
+
+        vm.prank(address(r));
+        vault.redeem(attackerShares, address(r), address(r));
+
+        // The callback fired (control was handed to the attacker during the ETH send).
+        assertTrue(r.reentered(), "callback never fired");
+
+        // CEI: shares are burned BEFORE the ETH send, so the reentrant party observes zero balance for
+        // itself and a totalSupply already reduced by exactly its shares.
+        assertEq(r.observedSelfBalance(), 0, "attacker shares not burned before ETH send (CEI violated)");
+        assertEq(
+            r.observedTotalSupply(),
+            totalSupplyBefore - attackerShares,
+            "totalSupply not reduced before ETH send (CEI violated)"
+        );
+
+        // (a) No over-extraction: the attacker received exactly what its shares entitled it to, no more.
+        //     The reentrant second redeem of the same (already-burned) shares cannot pay out anything extra.
+        assertEq(
+            address(r).balance,
+            expectedPayout,
+            "attacker extracted more native asset than its shares entitled it to"
+        );
+
+        // (b) No drain of other users: the vault retains at least the honest depositor's full entitlement,
+        //     and lost exactly the attacker's payout and nothing more.
+        assertEq(address(vault).balance, vaultBalBefore - expectedPayout, "vault over-drained");
+        assertGe(
+            address(vault).balance,
+            vault.previewRedeem(otherShares),
+            "vault cannot honor the honest depositor after the reentrant attempt (insolvent)"
+        );
+
+        // Solvency: only the honest depositor's shares remain.
+        assertEq(vault.balanceOf(address(r)), 0, "attacker still holds shares");
+        assertEq(vault.totalSupply(), otherShares, "share supply inconsistent after attack");
+
+        // The honest depositor can still fully withdraw afterwards (funds not bricked).
+        uint256 otherPayout = vault.previewRedeem(otherShares);
+        vm.prank(other);
+        uint256 redeemed = vault.redeem(otherShares, other, other);
+        assertEq(redeemed, otherPayout, "honest depositor could not redeem after attack");
+    }
+
+    function testReentrancyWithdrawCannotOverDrain() public {
+        _assertReentrancyCEI(ReentrantReceiver.Kind.Withdraw);
+    }
+
+    function testReentrancyRedeemCannotOverDrain() public {
+        _assertReentrancyCEI(ReentrantReceiver.Kind.Redeem);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Plain native-asset transfers to the vault (via `.call{value:}("")` / `transfer` / `send`)
+    // hit the `receive()` and MUST revert with `ERC7535UnsolicitedDeposit`. Force-feeding via
+    // `SELFDESTRUCT` / coinbase / `vm.deal` is the documented limitation: it bypasses the EVM
+    // code path entirely and still works (totalAssets rises), which is what the inflation-attack
+    // analysis already accounts for.
+    // --------------------------------------------------------------------------------------------
+
+    function testPlainEthTransferRevertsWithUnsolicitedDeposit() public {
+        // Fund a caller and try a plain low-level transfer to the vault.
+        address sender = makeAddr("plainSender");
+        vm.deal(sender, 1 ether);
+
+        uint256 totalAssetsBefore = vault.totalAssets();
+        uint256 vaultBalBefore = address(vault).balance;
+
+        vm.prank(sender);
+        (bool ok, bytes memory ret) = address(vault).call{value: 1}("");
+
+        // The receive() reverts with ERC7535UnsolicitedDeposit; the low-level call returns false
+        // and the revert data carries the custom-error selector.
+        assertFalse(ok, "plain ETH transfer to vault should fail");
+        assertEq(
+            bytes4(ret),
+            ERC7535.ERC7535UnsolicitedDeposit.selector,
+            "revert selector should be ERC7535UnsolicitedDeposit"
+        );
+
+        // The vault's balance and totalAssets are unchanged (no value entered).
+        assertEq(address(vault).balance, vaultBalBefore, "vault balance changed despite revert");
+        assertEq(vault.totalAssets(), totalAssetsBefore, "totalAssets changed despite revert");
+
+        // Sender's wei is fully refunded by the revert (still has its full 1 ether).
+        assertEq(sender.balance, 1 ether, "sender lost ETH despite revert");
+
+        // Force-feeding via vm.deal (the SELFDESTRUCT / coinbase analogue) bypasses the EVM code
+        // path entirely and still raises totalAssets — documented limitation of the `receive()` guard.
+        uint256 forceFed = 7 ether;
+        vm.deal(address(vault), vaultBalBefore + forceFed);
+        assertEq(vault.totalAssets(), totalAssetsBefore + forceFed, "force-feed via vm.deal did not raise totalAssets");
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Allowance path: third-party redeem must spend share allowance and cannot move another's shares.
+    // --------------------------------------------------------------------------------------------
+
+    function testThirdPartyRedeemRequiresAllowance() public {
+        vm.deal(victim, 3 ether);
+        vm.prank(victim);
+        uint256 shares = vault.deposit{value: 3 ether}(3 ether, victim);
+
+        // attacker has no allowance over victim's shares.
+        vm.prank(attacker);
+        vm.expectRevert();
+        vault.redeem(shares, attacker, victim);
+
+        // With allowance, it succeeds and burns exactly `shares` worth.
+        vm.prank(victim);
+        vault.approve(attacker, shares);
+        vm.prank(attacker);
+        vault.redeem(shares, attacker, victim);
+        assertEq(vault.balanceOf(victim), 0);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Outbound send failure: receiver whose `receive()` reverts must bubble the failure,
+    // and the vault's accounting must be untouched (state rolled back).
+    // --------------------------------------------------------------------------------------------
+
+    function testFuzzWithdrawToRevertingReceiverReverts(uint256 assets) public {
+        assets = bound(assets, 1, MAX_ETH);
+        // Seed: a victim deposits so the vault has shares and balance.
+        vm.deal(victim, assets);
+        vm.prank(victim);
+        vault.deposit{value: assets}(assets, victim);
+
+        // Receiver whose `receive()` always reverts.
+        RevertingReceiver rj = new RevertingReceiver();
+
+        uint256 balanceBefore = address(vault).balance;
+        uint256 supplyBefore = vault.totalSupply();
+        uint256 sharesBefore = vault.balanceOf(victim);
+
+        vm.prank(victim);
+        vm.expectRevert();
+        vault.withdraw(assets, address(rj), victim);
+
+        // State unchanged: revert rolled everything back.
+        assertEq(address(vault).balance, balanceBefore, "balance changed on a reverted withdraw");
+        assertEq(vault.totalSupply(), supplyBefore, "totalSupply changed on a reverted withdraw");
+        assertEq(vault.balanceOf(victim), sharesBefore, "shares changed on a reverted withdraw");
+    }
+}
+
+/// @dev Receiver whose `receive` always reverts — used to drive `Address.sendValue` into its failure branch.
+contract RevertingReceiver {
+    receive() external payable {
+        revert("nope");
+    }
+}
+
+// =================================================================================================
+// Invariant test: a handler that randomly deposits / withdraws / donates / redeems, with the core
+// solvency and no-profit invariants asserted on top.
+// =================================================================================================
+
+/// @dev Handler driving randomized vault interactions for the invariant suite. Tracks per-actor and
+/// global accounting so the invariants below can pin solvency and no-profit properties.
+contract ERC7535Handler is Test {
+    ERC7535VaultMock public vault;
+
+    address[] public actors;
+    mapping(address => uint256) public netInvested; // sum(deposits) − sum(redeemPayouts)
+    uint256 public totalDonated;
+
+    constructor(ERC7535VaultMock vault_, address[] memory actors_) {
+        vault = vault_;
+        actors = actors_;
+    }
+
+    function _pickActor(uint256 seed) internal view returns (address) {
+        return actors[seed % actors.length];
+    }
+
+    function handlerDeposit(uint256 seed, uint256 assets) external {
+        address actor = _pickActor(seed);
+        assets = bound(assets, 0, 1e22);
+        vm.deal(actor, actor.balance + assets);
+        vm.prank(actor);
+        vault.deposit{value: assets}(assets, actor);
+        netInvested[actor] += assets;
+    }
+
+    function handlerRedeem(uint256 seed, uint256 shares) external {
+        address actor = _pickActor(seed);
+        uint256 maxShares = vault.maxRedeem(actor);
+        if (maxShares == 0) return;
+        shares = bound(shares, 0, maxShares);
+        uint256 balBefore = actor.balance;
+        vm.prank(actor);
+        vault.redeem(shares, actor, actor);
+        uint256 payout = actor.balance - balBefore;
+        if (payout >= netInvested[actor]) {
+            netInvested[actor] = 0;
+        } else {
+            netInvested[actor] -= payout;
+        }
+    }
+
+    function handlerDonate(uint256 amount) external {
+        amount = bound(amount, 0, 1e18);
+        // Force-feed (SELFDESTRUCT/coinbase analogue): raises balance without minting shares.
+        vm.deal(address(vault), address(vault).balance + amount);
+        totalDonated += amount;
+    }
+
+    function sumNetInvested() external view returns (uint256 sum) {
+        for (uint256 i; i < actors.length; ++i) sum += netInvested[actors[i]];
+    }
+}
+
+contract ERC7535InvariantTest is Test {
+    ERC7535VaultMock internal vault;
+    ERC7535Handler internal handler;
+    address[] internal actors;
+
+    function setUp() public {
+        vault = new ERC7535VaultMock(0);
+
+        actors = new address[](3);
+        actors[0] = makeAddr("alice");
+        actors[1] = makeAddr("bob");
+        actors[2] = makeAddr("carol");
+
+        handler = new ERC7535Handler(vault, actors);
+
+        // Target only the handler's three entry points for the invariant runner.
+        bytes4[] memory selectors = new bytes4[](3);
+        selectors[0] = handler.handlerDeposit.selector;
+        selectors[1] = handler.handlerRedeem.selector;
+        selectors[2] = handler.handlerDonate.selector;
+        targetSelector(FuzzSelector({addr: address(handler), selectors: selectors}));
+        targetContract(address(handler));
+    }
+
+    /// @dev Solvency: the vault's native balance must always cover what every holder could redeem RIGHT NOW.
+    function invariantSolvency() public view {
+        uint256 owed = 0;
+        for (uint256 i; i < actors.length; ++i) {
+            owed += vault.previewRedeem(vault.balanceOf(actors[i]));
+        }
+        assertGe(address(vault).balance, owed, "vault balance < sum(previewRedeem(holders))");
+    }
+
+    /// @dev No value creation: the sum of currently-redeemable assets across holders is bounded by what they
+    /// actually put in plus what was donated (virtual-offset captures a sliver of donations; holders never
+    /// extract more than the deposits + donations together).
+    function invariantNoValueCreation() public view {
+        uint256 redeemable = 0;
+        for (uint256 i; i < actors.length; ++i) {
+            redeemable += vault.previewRedeem(vault.balanceOf(actors[i]));
+        }
+        assertLe(
+            redeemable,
+            handler.sumNetInvested() + handler.totalDonated(),
+            "holders can extract more than was put in"
+        );
+    }
+}

--- a/test/token/ERC20/extensions/ERC7535.test.js
+++ b/test/token/ERC20/extensions/ERC7535.test.js
@@ -1,0 +1,481 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture, setBalance } = require('@nomicfoundation/hardhat-network-helpers');
+const { PANIC_CODES } = require('@nomicfoundation/hardhat-chai-matchers/panic');
+
+const name = 'My Native Vault';
+const symbol = 'MNV';
+const decimals = 18n;
+
+// ERC-7528 native-asset placeholder (EIP-55 checksummed).
+const NATIVE_ASSET = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
+async function fixture() {
+  const [holder, recipient, spender, other, ...accounts] = await ethers.getSigners();
+  return { holder, recipient, spender, other, accounts };
+}
+
+describe('ERC7535', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  it('asset is the native-asset sentinel', async function () {
+    const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+    expect(await vault.asset()).to.equal(NATIVE_ASSET);
+  });
+
+  it('decimals are 18 + offset', async function () {
+    for (const offset of [0n, 6n, 18n]) {
+      const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, offset]);
+      expect(await vault.decimals()).to.equal(decimals + offset);
+    }
+  });
+
+  describe('reverts on msg.value mismatch', function () {
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('1000'));
+    });
+
+    it('deposit reverts when msg.value != assets', async function () {
+      const assets = ethers.parseEther('1');
+      await expect(this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets + 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC7535UnexpectedDepositValue')
+        .withArgs(assets + 1n, assets);
+
+      await expect(this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets - 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC7535UnexpectedDepositValue')
+        .withArgs(assets - 1n, assets);
+    });
+
+    it('deposit succeeds when msg.value == assets', async function () {
+      const assets = ethers.parseEther('1');
+      await expect(this.vault.connect(this.holder).deposit(assets, this.recipient, { value: assets })).to.not.be
+        .reverted;
+    });
+
+    it('mint reverts when msg.value != exact cost', async function () {
+      const shares = ethers.parseEther('1');
+      const cost = await this.vault.previewMint(shares);
+      await expect(this.vault.connect(this.holder).mint(shares, this.recipient, { value: cost + 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC7535UnexpectedMintValue')
+        .withArgs(cost + 1n, cost);
+
+      await expect(this.vault.connect(this.holder).mint(shares, this.recipient, { value: cost - 1n }))
+        .to.be.revertedWithCustomError(this.vault, 'ERC7535UnexpectedMintValue')
+        .withArgs(cost - 1n, cost);
+    });
+
+    it('mint succeeds when msg.value == exact cost', async function () {
+      const shares = ethers.parseEther('1');
+      const cost = await this.vault.previewMint(shares);
+      await expect(this.vault.connect(this.holder).mint(shares, this.recipient, { value: cost })).to.not.be.reverted;
+    });
+  });
+
+  describe('rejects plain ETH transfers', function () {
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('1000'));
+    });
+
+    it('receive() reverts with ERC7535UnsolicitedDeposit on a plain transfer', async function () {
+      await expect(this.holder.sendTransaction({ to: this.vault.target, value: 1n })).to.be.revertedWithCustomError(
+        this.vault,
+        'ERC7535UnsolicitedDeposit',
+      );
+    });
+
+    it('receive() reverts on a non-trivial plain transfer', async function () {
+      await expect(
+        this.holder.sendTransaction({ to: this.vault.target, value: ethers.parseEther('1') }),
+      ).to.be.revertedWithCustomError(this.vault, 'ERC7535UnsolicitedDeposit');
+    });
+
+    it('totalAssets does not increase after a rejected plain transfer', async function () {
+      const before = await this.vault.totalAssets();
+      await expect(this.holder.sendTransaction({ to: this.vault.target, value: 1n })).to.be.reverted;
+      expect(await this.vault.totalAssets()).to.equal(before);
+    });
+  });
+
+  describe('decimals offset bounds', function () {
+    // decimals() = 18 + _decimalsOffset() overflows the uint8 return type above 237.
+    for (const offset of [238n, 243n, 250n, 255n]) {
+      it(`decimals() reverts at offset ${offset}`, async function () {
+        const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, offset]);
+        await expect(vault.decimals()).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
+      });
+    }
+
+    // The conversion math computes 10 ** offset, which overflows uint256 from offset 78 onwards — the
+    // binding ceiling documented on _decimalsOffset. Pin both sides of the boundary.
+    it('conversions work at offset 77 (largest supported)', async function () {
+      const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 77n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+
+      expect(await vault.decimals()).to.equal(18n + 77n);
+      expect(await vault.previewDeposit(1n)).to.equal(10n ** 77n);
+      await expect(vault.connect(this.holder).deposit(1n, this.recipient, { value: 1n })).to.not.be.reverted;
+      expect(await vault.balanceOf(this.recipient)).to.equal(10n ** 77n);
+    });
+
+    it('conversions revert with an arithmetic panic at offset 78', async function () {
+      const vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 78n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+
+      // The vault deploys but every conversion-dependent entry point is bricked.
+      await expect(vault.previewDeposit(1n)).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
+      await expect(vault.previewMint(1n)).to.be.revertedWithPanic(PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW);
+      await expect(vault.connect(this.holder).deposit(1n, this.recipient, { value: 1n })).to.be.revertedWithPanic(
+        PANIC_CODES.ARITHMETIC_UNDER_OR_OVERFLOW,
+      );
+    });
+  });
+
+  describe('outbound send failure', function () {
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+      await this.vault.connect(this.holder).deposit(ethers.parseEther('1'), this.holder, {
+        value: ethers.parseEther('1'),
+      });
+      // A contract whose `receive()` always reverts — exercises the `Address.sendValue` failure path.
+      this.rejector = await ethers.deployContract('EtherReceiverMock');
+      await this.rejector.setAcceptEther(false);
+    });
+
+    it('withdraw to a receiver whose receive() reverts bubbles the failure', async function () {
+      await expect(this.vault.connect(this.holder).withdraw(ethers.parseEther('1'), this.rejector, this.holder)).to.be
+        .reverted;
+    });
+
+    it('redeem to a receiver whose receive() reverts bubbles the failure', async function () {
+      const shares = await this.vault.balanceOf(this.holder);
+      await expect(this.vault.connect(this.holder).redeem(shares, this.rejector, this.holder)).to.be.reverted;
+    });
+  });
+
+  describe('receiver == address(0) (documenting test)', function () {
+    // ERC4626 / ERC7535 don't require receiver != address(0) on withdraw/redeem; pin the current behavior
+    // (ETH sent to the zero address, which has no code and accepts the value silently) so a future change
+    // is forced to be deliberate.
+    beforeEach(async function () {
+      this.vault = await ethers.deployContract('$ERC7535OffsetMock', [name, symbol, 0n]);
+      await setBalance(this.holder.address, ethers.parseEther('10'));
+      await this.vault.connect(this.holder).deposit(ethers.parseEther('1'), this.holder, {
+        value: ethers.parseEther('1'),
+      });
+    });
+
+    it('withdraw to address(0) succeeds and sends value to the zero address', async function () {
+      const value = ethers.parseEther('1');
+      const tx = this.vault.connect(this.holder).withdraw(value, ethers.ZeroAddress, this.holder);
+      await expect(tx).to.changeEtherBalances([this.vault, ethers.ZeroAddress], [-value, value]);
+      await expect(tx).to.emit(this.vault, 'Withdraw');
+    });
+  });
+
+  for (const offset of [0n, 6n, 18n]) {
+    const parseAsset = asset => asset * 10n ** decimals;
+    const parseShare = share => share * 10n ** (decimals + offset);
+
+    const virtualAssets = 1n;
+    const virtualShares = 10n ** offset;
+
+    describe(`offset: ${offset}`, function () {
+      beforeEach(async function () {
+        const vault = await ethers.deployContract('$ERC7535OffsetMock', [name + ' Vault', symbol + 'V', offset]);
+
+        // Fund the holder with plenty of native asset.
+        await setBalance(this.holder.address, ethers.MaxUint256 / 2n);
+        // Approve spender over holder's shares for third-party withdraw/redeem paths.
+        await vault.$_approve(this.holder, this.spender, ethers.MaxUint256);
+
+        Object.assign(this, { vault });
+      });
+
+      it('metadata', async function () {
+        expect(await this.vault.name()).to.equal(name + ' Vault');
+        expect(await this.vault.symbol()).to.equal(symbol + 'V');
+        expect(await this.vault.decimals()).to.equal(decimals + offset);
+        expect(await this.vault.asset()).to.equal(NATIVE_ASSET);
+      });
+
+      describe('empty vault: no assets & no shares', function () {
+        it('status', async function () {
+          expect(await this.vault.totalAssets()).to.equal(0n);
+        });
+
+        it('deposit', async function () {
+          expect(await this.vault.maxDeposit(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewDeposit(parseAsset(1n))).to.equal(parseShare(1n));
+
+          const tx = this.vault.connect(this.holder).deposit(parseAsset(1n), this.recipient, { value: parseAsset(1n) });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-parseAsset(1n), parseAsset(1n)]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, parseShare(1n));
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, parseShare(1n))
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, parseAsset(1n), parseShare(1n));
+        });
+
+        it('mint', async function () {
+          expect(await this.vault.maxMint(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewMint(parseShare(1n))).to.equal(parseAsset(1n));
+
+          const tx = this.vault.connect(this.holder).mint(parseShare(1n), this.recipient, { value: parseAsset(1n) });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-parseAsset(1n), parseAsset(1n)]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, parseShare(1n));
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, parseShare(1n))
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, parseAsset(1n), parseShare(1n));
+        });
+
+        it('withdraw', async function () {
+          expect(await this.vault.maxWithdraw(this.holder)).to.equal(0n);
+          expect(await this.vault.previewWithdraw(0n)).to.equal(0n);
+
+          const tx = this.vault.connect(this.holder).withdraw(0n, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [0n, 0n]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, 0n);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, 0n)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, 0n, 0n);
+        });
+
+        it('redeem', async function () {
+          expect(await this.vault.maxRedeem(this.holder)).to.equal(0n);
+          expect(await this.vault.previewRedeem(0n)).to.equal(0n);
+
+          const tx = this.vault.connect(this.holder).redeem(0n, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [0n, 0n]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, 0n);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, 0n)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, 0n, 0n);
+        });
+      });
+
+      describe('inflation attack: offset price by direct donation of native asset', function () {
+        beforeEach(async function () {
+          // Force-feed 1 unit of native asset into the vault (SELFDESTRUCT / coinbase analogue): no shares minted.
+          await setBalance(this.vault.target, parseAsset(1n));
+        });
+
+        it('status', async function () {
+          expect(await this.vault.totalSupply()).to.equal(0n);
+          expect(await this.vault.totalAssets()).to.equal(parseAsset(1n));
+        });
+
+        it('deposit', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const depositAssets = parseAsset(1n);
+          const expectedShares = (depositAssets * effectiveShares) / effectiveAssets;
+
+          expect(await this.vault.maxDeposit(this.holder)).to.equal(ethers.MaxUint256);
+          // previewDeposit is queried BEFORE sending value: it sees the donated balance, not the in-flight value.
+          expect(await this.vault.previewDeposit(depositAssets)).to.equal(expectedShares);
+
+          const tx = this.vault.connect(this.holder).deposit(depositAssets, this.recipient, { value: depositAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-depositAssets, depositAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, expectedShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, expectedShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, depositAssets, expectedShares);
+        });
+
+        it('mint', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const mintShares = parseShare(1n);
+          const expectedAssets = (mintShares * effectiveAssets) / effectiveShares;
+
+          expect(await this.vault.maxMint(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewMint(mintShares)).to.equal(expectedAssets);
+
+          const tx = this.vault.connect(this.holder).mint(mintShares, this.recipient, { value: expectedAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-expectedAssets, expectedAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, mintShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, mintShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, expectedAssets, mintShares);
+        });
+      });
+
+      describe('full vault: assets & shares', function () {
+        beforeEach(async function () {
+          // 1 unit of native asset balance and 100 shares.
+          await setBalance(this.vault.target, parseAsset(1n));
+          await this.vault.$_mint(this.holder, parseShare(100n));
+        });
+
+        it('status', async function () {
+          expect(await this.vault.totalSupply()).to.equal(parseShare(100n));
+          expect(await this.vault.totalAssets()).to.equal(parseAsset(1n));
+        });
+
+        it('deposit', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const depositAssets = parseAsset(1n);
+          const expectedShares = (depositAssets * effectiveShares) / effectiveAssets;
+
+          expect(await this.vault.maxDeposit(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewDeposit(depositAssets)).to.equal(expectedShares);
+
+          const tx = this.vault.connect(this.holder).deposit(depositAssets, this.recipient, { value: depositAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-depositAssets, depositAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, expectedShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, expectedShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, depositAssets, expectedShares);
+        });
+
+        it('mint', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const mintShares = parseShare(1n);
+          const expectedAssets = (mintShares * effectiveAssets) / effectiveShares + 1n; // round up
+
+          expect(await this.vault.maxMint(this.holder)).to.equal(ethers.MaxUint256);
+          expect(await this.vault.previewMint(mintShares)).to.equal(expectedAssets);
+
+          const tx = this.vault.connect(this.holder).mint(mintShares, this.recipient, { value: expectedAssets });
+
+          await expect(tx).to.changeEtherBalances([this.holder, this.vault], [-expectedAssets, expectedAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.recipient, mintShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(ethers.ZeroAddress, this.recipient, mintShares)
+            .to.emit(this.vault, 'Deposit')
+            .withArgs(this.holder, this.recipient, expectedAssets, mintShares);
+        });
+
+        it('withdraw', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const withdrawAssets = parseAsset(1n);
+          const expectedShares = (withdrawAssets * effectiveShares) / effectiveAssets + 1n; // round up
+
+          expect(await this.vault.maxWithdraw(this.holder)).to.equal(withdrawAssets);
+          expect(await this.vault.previewWithdraw(withdrawAssets)).to.equal(expectedShares);
+
+          const tx = this.vault.connect(this.holder).withdraw(withdrawAssets, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [-withdrawAssets, withdrawAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, -expectedShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, expectedShares)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, withdrawAssets, expectedShares);
+        });
+
+        it('withdraw with approval', async function () {
+          const assets = await this.vault.previewWithdraw(parseAsset(1n));
+
+          await expect(this.vault.connect(this.other).withdraw(parseAsset(1n), this.recipient, this.holder))
+            .to.be.revertedWithCustomError(this.vault, 'ERC20InsufficientAllowance')
+            .withArgs(this.other, 0n, assets);
+
+          await expect(this.vault.connect(this.spender).withdraw(parseAsset(1n), this.recipient, this.holder)).to.not.be
+            .reverted;
+        });
+
+        it('redeem', async function () {
+          const effectiveAssets = (await this.vault.totalAssets()) + virtualAssets;
+          const effectiveShares = (await this.vault.totalSupply()) + virtualShares;
+
+          const redeemShares = parseShare(100n);
+          const expectedAssets = (redeemShares * effectiveAssets) / effectiveShares;
+
+          expect(await this.vault.maxRedeem(this.holder)).to.equal(redeemShares);
+          expect(await this.vault.previewRedeem(redeemShares)).to.equal(expectedAssets);
+
+          const tx = this.vault.connect(this.holder).redeem(redeemShares, this.recipient, this.holder);
+
+          await expect(tx).to.changeEtherBalances([this.vault, this.recipient], [-expectedAssets, expectedAssets]);
+          await expect(tx).to.changeTokenBalance(this.vault, this.holder, -redeemShares);
+          await expect(tx)
+            .to.emit(this.vault, 'Transfer')
+            .withArgs(this.holder, ethers.ZeroAddress, redeemShares)
+            .to.emit(this.vault, 'Withdraw')
+            .withArgs(this.holder, this.recipient, this.holder, expectedAssets, redeemShares);
+        });
+
+        it('redeem with approval', async function () {
+          await expect(this.vault.connect(this.other).redeem(parseShare(100n), this.recipient, this.holder))
+            .to.be.revertedWithCustomError(this.vault, 'ERC20InsufficientAllowance')
+            .withArgs(this.other, 0n, parseShare(100n));
+
+          await expect(this.vault.connect(this.spender).redeem(parseShare(100n), this.recipient, this.holder)).to.not.be
+            .reverted;
+        });
+      });
+    });
+  }
+
+  // Yield scenario adapted from the ERC-4626 suite to the native asset.
+  it('full vault: yield accrual via force-fed native asset', async function () {
+    const vault = await ethers.deployContract('$ERC7535', [name, symbol]);
+    const [alice, bruce] = this.accounts;
+
+    await setBalance(alice.address, ethers.parseEther('1000'));
+    await setBalance(bruce.address, ethers.parseEther('1000'));
+
+    // 1. Alice deposits 2000 wei
+    await vault.connect(alice).deposit(2000n, alice, { value: 2000n });
+    expect(await vault.balanceOf(alice)).to.equal(2000n);
+    expect(await vault.totalSupply()).to.equal(2000n);
+    expect(await vault.totalAssets()).to.equal(2000n);
+
+    // 2. Bruce deposits 4000 wei
+    await vault.connect(bruce).deposit(4000n, bruce, { value: 4000n });
+    expect(await vault.balanceOf(bruce)).to.equal(4000n);
+    expect(await vault.totalSupply()).to.equal(6000n);
+    expect(await vault.totalAssets()).to.equal(6000n);
+
+    // 3. Vault mutates by +3000 wei (simulated yield force-fed into the balance)
+    await setBalance(vault.target, 9000n);
+
+    // Virtual assets/shares capture a sliver of the yield (mirrors ERC-4626 behavior)
+    expect(await vault.convertToAssets(await vault.balanceOf(alice))).to.equal(2999n);
+    expect(await vault.convertToAssets(await vault.balanceOf(bruce))).to.equal(5999n);
+    expect(await vault.totalSupply()).to.equal(6000n);
+    expect(await vault.totalAssets()).to.equal(9000n);
+
+    // 4. Alice redeems all her shares; never extracts more than her fair share.
+    await expect(vault.connect(alice).redeem(2000n, alice, alice))
+      .to.emit(vault, 'Withdraw')
+      .withArgs(alice, alice, alice, 2999n, 2000n);
+    expect(await vault.balanceOf(alice)).to.equal(0n);
+  });
+});


### PR DESCRIPTION
This PR adds an implementation of [ERC-7535: Native Asset ERC-4626 Tokenized Vault](https://eips.ethereum.org/EIPS/eip-7535) — an adaptation of ERC-4626 in which the underlying asset is the chain's native asset (e.g. Ether) instead of an ERC-20 token. It complements the vault standards already in this repository (`ERC4626Fees`, `ERC7540`, `IERC7575`).

## What's included

- `contracts/interfaces/IERC7535.sol` — the full ERC-4626 interface surface with `payable` `deposit`/`mint`. It intentionally does not inherit `IERC4626`: Solidity does not allow a `payable` function to override a `nonpayable` one.
- `contracts/token/ERC20/extensions/ERC7535.sol` — abstract base implementation mirroring the structure, rounding directions, internal seams and virtual-offset anti-inflation math of the `ERC4626` implementation in `@openzeppelin/contracts`.
- `contracts/mocks/token/ERC7535OffsetMock.sol` — mock with configurable decimals offset.
- Hardhat + Foundry test suites, a documentation guide (`docs/modules/ROOT/pages/erc7535.adoc`), API doc registrations, and a changelog entry.

## Design decisions

- **`asset()`** returns the [ERC-7528](https://eips.ethereum.org/EIPS/eip-7528) native-asset placeholder (`0xEeee…EEeE`). Per ERC-7528/7535, a vault backed by a *wrapped* native asset (e.g. WETH9) must use plain ERC-4626 instead; this is documented as an `IMPORTANT` note.
- **`totalAssets()`** is balance-based (`address(this).balance`). Because `deposit`/`mint` are `payable`, the in-flight `msg.value` is already part of the balance when the exchange rate would be computed — naively using `totalAssets()` would misprice every deposit. The conversion math therefore prices against an internal `_pretotalAssets()` (= `totalAssets() - msg.value`), while all public previews use `totalAssets()` directly. Result: a standalone `previewDeposit(assets)` returns exactly the shares a subsequent `deposit` mints.
- **Exact `msg.value`**: `deposit(assets, receiver)` requires `msg.value == assets`, and `mint(shares, receiver)` requires `msg.value == previewMint(shares)`, reverting with typed errors otherwise. ERC-7535 allows ignoring the `assets` argument, but ignoring it lets a buggy integrator silently desync intent from payment; a refund path would introduce an outbound native call inside the deposit flow (reentrancy / refund-griefing surface). Strict equality keeps the `Deposit` event provably consistent with the wei that entered the vault. The guide documents why `deposit` should be preferred over `mint` for ETH-in flows.
- **Reentrancy**: withdrawals/redemptions send value via `Address.sendValue` (full gas, keeping smart-contract receivers like multisigs and AA wallets compatible) and rely on checks-effects-interactions — allowance spent and shares burned *before* the outbound transfer — matching `ERC4626`'s approach rather than adding a reentrancy guard.
- **Inflation attack**: same mitigation as `ERC4626` — virtual shares/assets parameterized by `_decimalsOffset()`. Note that a native-asset vault can always be force-fed balance (`SELFDESTRUCT`, block-reward/`coinbase` payments) bypassing any `receive` restriction, so the offset math — not balance gating — is the defense. The NatSpec documents that overrides must keep `offset <= 77`: `10 ** offset` overflows `uint256` beyond that, which would brick every conversion (the `uint8` `decimals()` bound alone would misleadingly allow up to 237). Regression tests pin both sides of the 77/78 boundary.
- **Unsolicited transfers**: `receive()` reverts with a named error (`ERC7535UnsolicitedDeposit`) so plain transfers fail loudly instead of silently skewing the exchange rate. It is `virtual`, so integrators that need plain native-asset payments to land (e.g. a rewards distributor on a chain without beacon-layer withdrawals) can deliberately open it.

## Testing

- **Hardhat (67 tests)**: parameterized over offsets `[0, 6, 18]` across empty / donated / populated vault states; `msg.value` mismatch reverts; unsolicited-transfer rejection; outbound-send failure to a reverting receiver; decimals/offset boundaries (237-ceiling overflow of `decimals()`, 77/78 conversion boundary); yield-accrual scenario adapted from the ERC-4626 suite.
- **Foundry (20 unit/fuzz + 2 invariant tests)**: preview/actual equivalence under non-trivial state, inflation-attack non-profitability at offset 0, deposit/mint round-trip contraction, force-fed balance accounting, CEI reentrancy tests with a malicious receiver that re-enters during the ETH push, and an invariant suite (`invariantSolvency`, `invariantNoValueCreation`) driven by a randomized handler (5000 runs × 500 calls, 0 reverts).

All repo checks pass locally: `npm run lint`, Hardhat + Foundry suites, `test:inheritance`, `test:pragma`, `test:generation`, and docgen (`{{ERC7535}}` / `{{IERC7535}}` placeholders resolve).

#### PR Checklist

- [x] Tests
- [x] Documentation
- [x] Changelog entry


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ERC-7535 native-asset vault implementation supporting deposit, mint, withdraw, and redeem operations with native assets.
  * Includes inflation attack mitigation via configurable virtual shares.
  * Provides a reverting receive handler to reject unsolicited native transfers.

* **Documentation**
  * Added comprehensive ERC-7535 documentation with integration guidelines.
  * Updated interface and extension references.

* **Tests**
  * Added extensive unit, fuzz, and invariant test coverage for vault accounting, reentrancy safety, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->