### PR TITLE
Reject ERC20uRWA forced transfer to self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 25-06-2026
+
+- `ERC20uRWA`: Reject `forcedTransfer` when `from == to`, preventing a self-directed forced transfer from reducing the frozen balance without moving any tokens (an unauthorized unfreeze that bypassed the freezer role).
+
 ## 28-04-2026
 
 - `IERC7540`: Add interface for ERC-7540 asynchronous tokenized vaults, extending ERC-4626 with request-based deposit and redeem flows.

--- a/contracts/token/ERC20/extensions/ERC20uRWA.sol
+++ b/contracts/token/ERC20/extensions/ERC20uRWA.sol
@@ -71,6 +71,10 @@ abstract contract ERC20uRWA is ERC20, ERC165, ERC20Freezable, ERC20Restricted, I
     function forcedTransfer(address from, address to, uint256 amount) public virtual returns (bool result) {
         _checkEnforcer(from, to, amount);
         require(canTransact(to), ERC7943CannotTransact(to));
+        // A forced transfer to self moves no tokens, but the frozen balance adjustment below would still
+        // lower the frozen amount, effectively acting as an unauthorized unfreeze. Rejecting it preserves
+        // the separation between the enforcer and freezer roles.
+        require(from != to, ERC7943CannotTransfer(from, to, amount));
 
         // Update frozen balance if needed. ERC-7943 requires that balance is unfrozen first and then send the tokens.
         uint256 currentFrozen = frozen(from);

--- a/test/token/ERC20/extensions/ERC20uRWA.test.js
+++ b/test/token/ERC20/extensions/ERC20uRWA.test.js
@@ -252,6 +252,20 @@ describe('ERC20uRWA', function () {
 
         await expect(this.token.frozen(this.holder)).to.eventually.equal(frozenAmount);
       });
+
+      it('reverts when force transferring to self and does not reduce the frozen balance', async function () {
+        const frozenAmount = initialSupply; // Fully frozen
+        await this.token.connect(this.freezer).setFrozenTokens(this.holder, frozenAmount);
+
+        // A forced transfer to self moves no tokens but would otherwise lower the frozen balance,
+        // acting as an unauthorized unfreeze that bypasses the freezer role. It must revert instead.
+        await expect(this.token.connect(this.enforcer).forcedTransfer(this.holder, this.holder, frozenAmount))
+          .to.be.revertedWithCustomError(this.token, 'ERC7943CannotTransfer')
+          .withArgs(this.holder, this.holder, frozenAmount);
+
+        // The frozen balance is left untouched.
+        await expect(this.token.frozen(this.holder)).to.eventually.equal(frozenAmount);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #244

### Problem

`ERC20uRWA.forcedTransfer(from, to, amount)` does not reject `from == to`. In that case `_update(from, to, amount)` moves no tokens, but the frozen-balance adjustment runs first:

```solidity
uint256 currentFrozen = frozen(from);
uint256 newBalance;
unchecked { newBalance = balanceOf(from) - amount; }
if (currentFrozen > newBalance) {
    _setFrozen(from, newBalance);
}
```

So a self-directed forced transfer leaves the balance unchanged while **lowering the frozen amount** — an implicit, unauthorized unfreeze. This is most relevant when the enforcer and freezer permissions are held by different entities: an enforcer could reduce frozen balances without holding the freezer role, breaking the intended separation of duties (also noted for the ERC-7943 reference implementation in ethereum/ERCs#1778).

Example: `balanceOf(alice) = 100`, `frozen(alice) = 100`. Calling `forcedTransfer(alice, alice, 100)` results in `frozen(alice) = 0` with the balance untouched.

### Fix

Reject the degenerate self-transfer by reverting with the existing `ERC7943CannotTransfer(from, to, amount)` error before any state changes:

```solidity
require(from != to, ERC7943CannotTransfer(from, to, amount));
```

### Scope

This PR addresses point **1** of #244 (the self-forced-transfer edge case), which is a contained correctness/security fix. Points 2–4 in that issue (the `setFrozenTokens` balance cap, the `canSend`/`canReceive` vs `canTransact` interface split, and `canTransfer` semantics) are interface/semantic decisions and are intentionally left out of this PR for the maintainers to decide separately.

#### PR Checklist

- [x] Tests — added a regression test asserting `forcedTransfer(holder, holder, ...)` reverts and leaves the frozen balance untouched; full `ERC20uRWA` suite passes (40 passing).
- [x] Documentation — added a `CHANGELOG.md` entry and an explanatory code comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forced transfers now correctly reject attempts to send tokens to the same address, preventing frozen balances from being reduced without any token movement.
  * Self-directed forced transfers now fail with a clear error and leave balances unchanged.

* **Tests**
  * Added coverage to verify same-address forced transfers revert as expected and preserve frozen token balances.

* **Documentation**
  * Updated the changelog with the latest behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->