### PR TITLE
Fix ERC20uRWA canTransfer/forcedTransfer restriction checks

### DIFF
--- a/contracts/token/ERC20/extensions/ERC20uRWA.sol
+++ b/contracts/token/ERC20/extensions/ERC20uRWA.sol
@@ -30,13 +30,31 @@ abstract contract ERC20uRWA is ERC20, ERC165, ERC20Freezable, ERC20Restricted, I
     }
 
     /**
+     * @dev Returns whether `account` is allowed to send tokens. Defaults to {canTransact}.
+     *
+     * Override to implement sender-specific restrictions distinct from {canReceive}.
+     */
+    function canSend(address account) public view virtual returns (bool) {
+        return canTransact(account);
+    }
+
+    /**
+     * @dev Returns whether `account` is allowed to receive tokens. Defaults to {canTransact}.
+     *
+     * Override to implement recipient-specific restrictions distinct from {canSend}.
+     */
+    function canReceive(address account) public view virtual returns (bool) {
+        return canTransact(account);
+    }
+
+    /**
      * @dev See {IERC7943Fungible-canTransfer}.
      *
      * CAUTION: This function is only meant for external use. Overriding it will not apply the new checks to
      * the internal {_update} function. Consider overriding {_update} accordingly to keep both functions in sync.
      */
-    function canTransfer(address from, address to, uint256 amount) external view virtual returns (bool) {
-        return (amount <= available(from) && canTransact(from) && canTransact(to));
+    function canTransfer(address from, address to, uint256 /* amount */) external view virtual returns (bool) {
+        return (canSend(from) && canReceive(to));
     }
 
     /// @inheritdoc IERC7943Fungible
@@ -70,7 +88,7 @@ abstract contract ERC20uRWA is ERC20, ERC165, ERC20Freezable, ERC20Restricted, I
      */
     function forcedTransfer(address from, address to, uint256 amount) public virtual returns (bool result) {
         _checkEnforcer(from, to, amount);
-        require(canTransact(to), ERC7943CannotTransact(to));
+        require(canReceive(to), ERC7943CannotTransact(to));
 
         // Update frozen balance if needed. ERC-7943 requires that balance is unfrozen first and then send the tokens.
         uint256 currentFrozen = frozen(from);

--- a/test/token/ERC20/extensions/ERC20uRWA.t.sol
+++ b/test/token/ERC20/extensions/ERC20uRWA.t.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC7943Fungible} from "@openzeppelin/community-contracts/interfaces/IERC7943.sol";
+import {ERC20uRWAMock} from "./ERC20uRWAMock.t.sol";
+
+contract ERC20uRWATest is Test {
+    ERC20uRWAMock public token;
+
+    address public holder = makeAddr("holder");
+    address public recipient = makeAddr("recipient");
+    address public freezer = makeAddr("freezer");
+    address public enforcer = makeAddr("enforcer");
+
+    uint256 public constant INITIAL_SUPPLY = 100;
+
+    function setUp() public {
+        token = new ERC20uRWAMock("My uRWA Token", "uRWA", freezer, enforcer);
+        token.mint(holder, INITIAL_SUPPLY);
+    }
+
+    // --- canTransfer: balance check removed ---
+
+    function test_canTransfer_trueWhenAmountExceedsAvailableBalance() public view {
+        uint256 amount = INITIAL_SUPPLY + 1000;
+        assertTrue(token.canTransfer(holder, recipient, amount));
+    }
+
+    function test_canTransfer_trueWhenAmountExceedsAvailableDueToFrozenTokens() public {
+        vm.prank(freezer);
+        token.setFrozenTokens(holder, 80);
+
+        // Available = 100 - 80 = 20, but requesting more than available.
+        assertTrue(token.canTransfer(holder, recipient, 30));
+    }
+
+    function test_canTransfer_trueForZeroBalanceSender() public {
+        address emptyAccount = makeAddr("emptyAccount");
+        assertTrue(token.canTransfer(emptyAccount, recipient, 1));
+    }
+
+    // --- canTransfer: canSend / canReceive gating ---
+
+    function test_canTransfer_falseWhenCanSendFalse() public {
+        token.setCanSend(holder, false);
+        assertFalse(token.canTransfer(holder, recipient, 10));
+    }
+
+    function test_canTransfer_falseWhenCanReceiveFalse() public {
+        token.setCanReceive(recipient, false);
+        assertFalse(token.canTransfer(holder, recipient, 10));
+    }
+
+    function test_canTransfer_trueWhenCanSendAndCanReceiveTrue() public {
+        token.setCanSend(holder, true);
+        token.setCanReceive(recipient, true);
+        assertTrue(token.canTransfer(holder, recipient, 10));
+    }
+
+    function test_canTransfer_defaultsToCanTransactWhenNotOverridden() public {
+        // No overrides set: canSend/canReceive fall back to canTransact, which defaults to true.
+        assertTrue(token.canTransfer(holder, recipient, 10));
+
+        token.blockUser(holder);
+        assertFalse(token.canTransfer(holder, recipient, 10));
+    }
+
+    // --- forcedTransfer: canReceive(to) enforcement ---
+
+    function test_forcedTransfer_revertsWhenCanReceiveFalse() public {
+        token.setCanReceive(recipient, false);
+
+        vm.prank(enforcer);
+        vm.expectRevert(abi.encodeWithSelector(IERC7943Fungible.ERC7943CannotTransact.selector, recipient));
+        token.forcedTransfer(holder, recipient, 10);
+    }
+
+    function test_forcedTransfer_succeedsWhenReceiveAllowedByDefault() public {
+        vm.prank(enforcer);
+        bool result = token.forcedTransfer(holder, recipient, 10);
+        assertTrue(result);
+        assertEq(token.balanceOf(holder), INITIAL_SUPPLY - 10);
+        assertEq(token.balanceOf(recipient), 10);
+    }
+
+    // --- asymmetric send/receive permissions ---
+
+    function test_accountCanReceiveButNotSend() public {
+        // holder can send (default), recipient explicitly cannot send but can receive.
+        token.setCanSend(recipient, false);
+        token.setCanReceive(recipient, true);
+
+        // holder -> recipient: holder can send, recipient can receive => true
+        assertTrue(token.canTransfer(holder, recipient, 10));
+
+        // recipient -> holder: recipient cannot send => false
+        assertFalse(token.canTransfer(recipient, holder, 10));
+    }
+
+    function test_accountCanSendButNotReceive() public {
+        // holder explicitly can send but cannot receive.
+        token.setCanSend(holder, true);
+        token.setCanReceive(holder, false);
+
+        // recipient -> holder: holder cannot receive => false
+        assertFalse(token.canTransfer(recipient, holder, 10));
+
+        // holder -> recipient: holder can send, recipient can receive (default) => true
+        assertTrue(token.canTransfer(holder, recipient, 10));
+    }
+}

--- a/test/token/ERC20/extensions/ERC20uRWAMock.t.sol
+++ b/test/token/ERC20/extensions/ERC20uRWAMock.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {ERC20uRWA} from "@openzeppelin/community-contracts/token/ERC20/extensions/ERC20uRWA.sol";
+
+contract ERC20uRWAMock is ERC20uRWA, AccessControl {
+    bytes32 public constant FREEZER_ROLE = keccak256("FREEZER_ROLE");
+    bytes32 public constant ENFORCER_ROLE = keccak256("ENFORCER_ROLE");
+
+    mapping(address => bool) private _sendOverride;
+    mapping(address => bool) private _receiveOverride;
+    mapping(address => bool) private _sendOverrideSet;
+    mapping(address => bool) private _receiveOverrideSet;
+
+    constructor(
+        string memory name,
+        string memory symbol,
+        address freezer,
+        address enforcer
+    ) ERC20(name, symbol) {
+        _grantRole(FREEZER_ROLE, freezer);
+        _grantRole(ENFORCER_ROLE, enforcer);
+    }
+
+    function mint(address account, uint256 amount) public {
+        _mint(account, amount);
+    }
+
+    function setCanSend(address account, bool allowed) public {
+        _sendOverride[account] = allowed;
+        _sendOverrideSet[account] = true;
+    }
+
+    function setCanReceive(address account, bool allowed) public {
+        _receiveOverride[account] = allowed;
+        _receiveOverrideSet[account] = true;
+    }
+
+    function canSend(address account) public view override returns (bool) {
+        if (_sendOverrideSet[account]) return _sendOverride[account];
+        return super.canSend(account);
+    }
+
+    function canReceive(address account) public view override returns (bool) {
+        if (_receiveOverrideSet[account]) return _receiveOverride[account];
+        return super.canReceive(account);
+    }
+
+    function blockUser(address account) public {
+        _blockUser(account);
+    }
+
+    function allowUser(address account) public {
+        _allowUser(account);
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC20uRWA, AccessControl) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _checkEnforcer(address, address, uint256) internal view override onlyRole(ENFORCER_ROLE) {}
+
+    function _checkFreezer(address, uint256) internal view override onlyRole(FREEZER_ROLE) {}
+}


### PR DESCRIPTION
## Summary

Fixes #244 (points 3 & 4).

- Add virtual `canSend(address)` and `canReceive(address)`, both defaulting to `canTransact()`, so send-side and receive-side restrictions can be overridden independently.
- `canTransfer()`: remove the `amount <= available(from)` balance check (a `canTransfer` availability query shouldn't also encode balance sufficiency) and check `canSend(from) && canReceive(to)` instead of `canTransact(from) && canTransact(to)`.
- `forcedTransfer()`: gate the recipient with `canReceive(to)` instead of `canTransact(to)`, consistent with `canTransfer`.

No changes to `setFrozenTokens`, the `forcedTransfer` `from == to` handling, or any other files.

## Test plan

- [x] `forge build` passes
- [x] `forge test` passes (41/41, including 11 new tests in `test/token/ERC20/extensions/ERC20uRWA.t.sol`)
- New tests cover:
  - `canTransfer` returns `true` even when `amount` exceeds available/frozen balance
  - `canTransfer` returns `false` when `canSend` or `canReceive` is false
  - `forcedTransfer` reverts when `canReceive` is false
  - Accounts that can receive but not send, and vice versa