### PR TITLE
Add ERC20UniversalWrapper, a clone-based universal ERC-20 wrapper

### DIFF
--- a/contracts/token/ERC20/examples/ERC20UniversalWrapperFactory.sol
+++ b/contracts/token/ERC20/examples/ERC20UniversalWrapperFactory.sol
@@ -8,13 +8,19 @@ import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-// prettier-ignore
-import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
-// prettier-ignore
-import {ERC20FlashMintUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20FlashMintUpgradeable.sol";
+import {
+    ERC20PermitUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import {
+    ERC20FlashMintUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20FlashMintUpgradeable.sol";
+import {
+    ERC20TemporaryApprovalUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20TemporaryApprovalUpgradeable.sol";
 import {ERC1363Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC1363Upgradeable.sol";
-// prettier-ignore
-import {ERC3009Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC3009Upgradeable.sol";
+import {
+    ERC3009Upgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC3009Upgradeable.sol";
 import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
 
 /// @dev Settings flag enabling a variable (vault-like) exchange rate between the underlying asset and the wrapper.
@@ -31,8 +37,8 @@ uint8 constant _FLASH_MINT_FLAG = 0x02;
  * but appended to the clone's bytecode and read back on demand by {_parseArgs}. Consequently, a given (asset,
  * settings) pair maps to a single deterministic wrapper address, and deploying a wrapper costs no storage writes.
  *
- * The wrapper exposes {IERC20Permit}, {IERC1363}, {IERC3009} and {IERC4626} on top of the wrapped asset. Two
- * behaviors are configurable per clone, through the settings byte:
+ * The wrapper exposes {IERC20Permit}, {IERC1363}, {IERC3009}, {IERC4626} and {IERC7674} on top of the wrapped asset.
+ * Two behaviors are configurable per clone, through the settings byte:
  *
  * * {_VARIABLE_RATE_FLAG}: when unset, the wrapper behaves like a 1:1 wrapper (as {ERC20Wrapper} would). When set,
  *   the wrapper behaves like a normal {ERC4626} vault, whose exchange rate follows the assets it holds.
@@ -48,6 +54,7 @@ uint8 constant _FLASH_MINT_FLAG = 0x02;
 contract ERC20UniversalWrapper is
     ERC20PermitUpgradeable,
     ERC20FlashMintUpgradeable,
+    ERC20TemporaryApprovalUpgradeable,
     ERC1363Upgradeable,
     ERC3009Upgradeable,
     ERC4626Upgradeable
@@ -136,6 +143,27 @@ contract ERC20UniversalWrapper is
         require(cloneArgs.length == 21, MissingImmutableArgs());
         bytes21 data = bytes21(cloneArgs);
         return (address(bytes20(data)), uint8(bytes1(data << 160)));
+    }
+
+    // ===============================================================================================================
+    // =                                       Overrides required by Solidity                                        =
+    // ===============================================================================================================
+
+    /// @inheritdoc ERC20TemporaryApprovalUpgradeable
+    function allowance(
+        address owner,
+        address spender
+    ) public view override(IERC20, ERC20Upgradeable, ERC20TemporaryApprovalUpgradeable) returns (uint256) {
+        return super.allowance(owner, spender);
+    }
+
+    /// @inheritdoc ERC20TemporaryApprovalUpgradeable
+    function _spendAllowance(
+        address owner,
+        address spender,
+        uint256 value
+    ) internal override(ERC20Upgradeable, ERC20TemporaryApprovalUpgradeable) {
+        super._spendAllowance(owner, spender, value);
     }
 }
 

--- a/contracts/token/ERC20/examples/ERC20UniversalWrapperFactory.sol
+++ b/contracts/token/ERC20/examples/ERC20UniversalWrapperFactory.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+// Compatible with OpenZeppelin Contracts ^5.7.0
+pragma solidity ^0.8.27;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+// prettier-ignore
+import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+// prettier-ignore
+import {ERC20FlashMintUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20FlashMintUpgradeable.sol";
+import {ERC1363Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC1363Upgradeable.sol";
+// prettier-ignore
+import {ERC3009Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC3009Upgradeable.sol";
+import {ERC4626Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC4626Upgradeable.sol";
+
+/// @dev Settings flag enabling a variable (vault-like) exchange rate between the underlying asset and the wrapper.
+uint8 constant _VARIABLE_RATE_FLAG = 0x01;
+
+/// @dev Settings flag enabling {IERC3156FlashLender} flash loans of the wrapper token.
+uint8 constant _FLASH_MINT_FLAG = 0x02;
+
+/**
+ * @dev Wrapper for any {IERC20} token, deployable as a minimal clone by {ERC20UniversalWrapperFactory}.
+ *
+ * This contract is meant to be used as the implementation behind {Clones}' "clone with immutable args" proxies. It
+ * has no constructor and no initializer: the underlying asset and the feature switches are not stored in storage,
+ * but appended to the clone's bytecode and read back on demand by {_parseArgs}. Consequently, a given (asset,
+ * settings) pair maps to a single deterministic wrapper address, and deploying a wrapper costs no storage writes.
+ *
+ * The wrapper exposes {IERC20Permit}, {IERC1363}, {IERC3009} and {IERC4626} on top of the wrapped asset. Two
+ * behaviors are configurable per clone, through the settings byte:
+ *
+ * * {_VARIABLE_RATE_FLAG}: when unset, the wrapper behaves like a 1:1 wrapper (as {ERC20Wrapper} would). When set,
+ *   the wrapper behaves like a normal {ERC4626} vault, whose exchange rate follows the assets it holds.
+ * * {_FLASH_MINT_FLAG}: when set, the wrapper token can be flash-minted. This is only available for 1:1 wrappers,
+ *   as flash minting shares would otherwise interfere with the vault's exchange rate.
+ *
+ * The name and symbol are derived from the underlying asset's metadata, and are therefore not stored either.
+ *
+ * NOTE: The underlying asset's metadata is read on every call to {name}, {symbol} and {decimals}. Wrapping an asset
+ * whose {IERC20Metadata} functions revert (or are not implemented) will make {name} and {symbol} revert too.
+ * {decimals} degrades gracefully to 18.
+ */
+contract ERC20UniversalWrapper is
+    ERC20PermitUpgradeable,
+    ERC20FlashMintUpgradeable,
+    ERC1363Upgradeable,
+    ERC3009Upgradeable,
+    ERC4626Upgradeable
+{
+    /// @dev The clone's immutable args are missing or too short to hold the underlying asset and the settings byte.
+    error MissingImmutableArgs();
+
+    // No constructor + no initializer
+    // ---
+    // All storage variables usually set in the constructor are instead set via immutable args, which are read from
+    // the clone's bytecode.
+
+    // ===============================================================================================================
+    // =                                          Overall wrapper behavior                                           =
+    // ===============================================================================================================
+
+    /// @dev Address of the underlying token being wrapped, read from the clone's immutable args.
+    function asset() public view override returns (address _asset) {
+        (_asset, ) = _parseArgs();
+    }
+
+    /// @dev Name of the wrapper: the underlying asset's name, prefixed with `"Wrapped "`.
+    function name() public view override(ERC20Upgradeable, IERC20Metadata) returns (string memory) {
+        return string.concat("Wrapped ", IERC20Metadata(asset()).name());
+    }
+
+    /// @dev Symbol of the wrapper: the underlying asset's symbol, prefixed with `"w"`.
+    function symbol() public view override(ERC20Upgradeable, IERC20Metadata) returns (string memory) {
+        return string.concat("w", IERC20Metadata(asset()).symbol());
+    }
+
+    /// @dev Decimals of the wrapper, mirroring the underlying asset's decimals, or 18 if the asset doesn't expose any.
+    function decimals() public view override(ERC20Upgradeable, ERC4626Upgradeable) returns (uint8) {
+        (bool success, uint8 _decimals) = SafeERC20.tryGetDecimals(IERC20Metadata(asset()));
+        return (success ? _decimals : 18) + _decimalsOffset();
+    }
+
+    /// @dev EIP-712 domain name, matching {name} so that each clone gets its own domain separator.
+    function _EIP712Name() internal view override returns (string memory) {
+        return name();
+    }
+
+    /// @dev EIP-712 domain version.
+    function _EIP712Version() internal pure override returns (string memory) {
+        return "1";
+    }
+
+    // ===============================================================================================================
+    // =                                              Feature switches                                               =
+    // ===============================================================================================================
+
+    /**
+     * @dev See {ERC20FlashMint-maxFlashLoan}. Returns 0 unless this clone was deployed with the
+     * {_FLASH_MINT_FLAG} setting, effectively disabling flash loans.
+     */
+    function maxFlashLoan(address token) public view override returns (uint256) {
+        (, uint8 settings) = _parseArgs();
+        return settings & _FLASH_MINT_FLAG == 0 ? 0 : super.maxFlashLoan(token);
+    }
+
+    /**
+     * @dev Internal conversion function (from assets to shares) with support for rounding direction. Unless this
+     * clone was deployed with the {_VARIABLE_RATE_FLAG} setting, the rate is fixed to 1:1.
+     */
+    function _convertToShares(uint256 assets, Math.Rounding rounding) internal view override returns (uint256) {
+        (, uint8 settings) = _parseArgs();
+        return settings & _VARIABLE_RATE_FLAG == 0 ? assets : super._convertToShares(assets, rounding);
+    }
+
+    /**
+     * @dev Internal conversion function (from shares to assets) with support for rounding direction. Unless this
+     * clone was deployed with the {_VARIABLE_RATE_FLAG} setting, the rate is fixed to 1:1.
+     */
+    function _convertToAssets(uint256 shares, Math.Rounding rounding) internal view override returns (uint256) {
+        (, uint8 settings) = _parseArgs();
+        return settings & _VARIABLE_RATE_FLAG == 0 ? shares : super._convertToAssets(shares, rounding);
+    }
+
+    /**
+     * @dev Reads the clone's immutable args, and decodes them into the underlying asset's address and the settings
+     * byte. Reverts with {MissingImmutableArgs} if the args are not exactly the expected 21 bytes, which notably
+     * happens when calling the implementation contract directly instead of one of its clones.
+     */
+    function _parseArgs() private view returns (address underlying, uint8 settings) {
+        bytes memory cloneArgs = Clones.fetchCloneArgs(address(this));
+        require(cloneArgs.length == 21, MissingImmutableArgs());
+        bytes21 data = bytes21(cloneArgs);
+        return (address(bytes20(data)), uint8(bytes1(data << 160)));
+    }
+}
+
+/**
+ * @dev Factory for {ERC20UniversalWrapper} clones.
+ *
+ * Deploying this factory also deploys the single {ERC20UniversalWrapper} implementation that all wrappers delegate
+ * to. Wrappers are then deployed as "clones with immutable args", using a zero salt, which makes the resulting
+ * address a pure function of the implementation, the underlying asset and the settings. Deployment is therefore
+ * permissionless and idempotent: anyone can deploy the wrapper for a given configuration, but only once. Use
+ * {predict} to compute that address ahead of (or without) deployment.
+ */
+contract ERC20UniversalWrapperFactory {
+    /// @dev A variable rate wrapper was requested alongside flash minting, which are mutually exclusive.
+    error IncompatibleSettings();
+
+    /// @dev Address of the {ERC20UniversalWrapper} implementation that every wrapper deployed here delegates to.
+    address public immutable implementation = address(new ERC20UniversalWrapper());
+
+    /// @dev A wrapper for `underlying`, with the given `settings`, was deployed at `wrapper`.
+    event ERC20UniversalWrapperDeployed(address indexed wrapper, address indexed underlying, uint8 settings);
+
+    /**
+     * @dev Deploys the {ERC20UniversalWrapper} for the given `underlying` token and settings, and returns its
+     * address.
+     *
+     * Setting `variableRate` makes the wrapper behave like a normal {ERC4626} vault instead of a 1:1 wrapper.
+     * Setting `flashMintable` enables flash minting of the wrapper token. These two options are mutually exclusive.
+     *
+     * NOTE: This reverts if the corresponding wrapper was already deployed. Since the address only depends on the
+     * arguments, that existing wrapper (retrievable using {predict}) is exactly the one this call would produce.
+     */
+    function deploy(address underlying, bool variableRate, bool flashMintable) external returns (address) {
+        // prepare settings
+        uint8 settings = _makeSettings(variableRate, flashMintable);
+
+        // deploy wrapper
+        address instance = Clones.cloneDeterministicWithImmutableArgs(
+            implementation,
+            abi.encodePacked(underlying, settings),
+            bytes32(0)
+        );
+
+        emit ERC20UniversalWrapperDeployed(instance, underlying, settings);
+        return instance;
+    }
+
+    /**
+     * @dev Returns the address at which the {ERC20UniversalWrapper} for the given `underlying` token and settings
+     * is (or would be) deployed. See {deploy} for the meaning of `variableRate` and `flashMintable`.
+     */
+    function predict(address underlying, bool variableRate, bool flashMintable) external view returns (address) {
+        return
+            Clones.predictDeterministicAddressWithImmutableArgs(
+                implementation,
+                abi.encodePacked(underlying, _makeSettings(variableRate, flashMintable)),
+                bytes32(0)
+            );
+    }
+
+    /**
+     * @dev Packs the feature switches into the settings byte stored in the clone's immutable args. Reverts with
+     * {IncompatibleSettings} if the requested combination is invalid: a variable rate wrapper cannot be flash
+     * mintable, as flash minting shares would interfere with the vault's exchange rate.
+     */
+    function _makeSettings(bool variableRate, bool flashMintable) private pure returns (uint8 settings) {
+        require(!variableRate || !flashMintable, IncompatibleSettings());
+        return (variableRate ? _VARIABLE_RATE_FLAG : 0) | (flashMintable ? _FLASH_MINT_FLAG : 0);
+    }
+}

--- a/test/token/ERC20/examples/ERC20UniversalWrapperFactory.test.js
+++ b/test/token/ERC20/examples/ERC20UniversalWrapperFactory.test.js
@@ -1,0 +1,211 @@
+const { ethers } = require('hardhat');
+const { expect } = require('chai');
+const { loadFixture } = require('@nomicfoundation/hardhat-network-helpers');
+const { getDomain, domainSeparator } = require('@openzeppelin/contracts/test/helpers/eip712');
+
+const VARIABLE_RATE_FLAG = 0x01n;
+const FLASH_MINT_FLAG = 0x02n;
+
+const tokenName = 'Asset Token';
+const tokenSymbol = 'AST';
+const configs = [
+  { description: 'fixed rate wrapper', args: [false, false] },
+  { description: 'variable rate wrapper', args: [true, false] },
+  { description: 'flash mintable wrapper', args: [false, true] },
+];
+
+async function fixture() {
+  const [holder, other] = await ethers.getSigners();
+
+  const token = await ethers.deployContract('$ERC20', [tokenName, tokenSymbol]);
+  const otherToken = await ethers.deployContract('$ERC20', ['Other Token', 'OTH']);
+  const factory = await ethers.deployContract('ERC20UniversalWrapperFactory');
+  const implementation = await factory
+    .implementation()
+    .then(address => ethers.getContractAt('ERC20UniversalWrapper', address));
+
+  return { holder, other, token, otherToken, factory, implementation };
+}
+
+describe('ERC20UniversalWrapperFactory', function () {
+  beforeEach(async function () {
+    Object.assign(this, await loadFixture(fixture));
+  });
+
+  describe('implementation', function () {
+    it('is deployed along with the factory', async function () {
+      await expect(ethers.provider.getCode(this.implementation)).to.eventually.not.equal('0x');
+    });
+
+    it('cannot be used directly, as it has no immutable args', async function () {
+      await expect(this.implementation.asset()).to.be.revertedWithCustomError(
+        this.implementation,
+        'MissingImmutableArgs',
+      );
+      await expect(this.implementation.name()).to.be.revertedWithCustomError(
+        this.implementation,
+        'MissingImmutableArgs',
+      );
+    });
+  });
+
+  describe('predict', function () {
+    it('predicted/deployment address depends on the settings', async function () {
+      const allAddresses = await Promise.all(configs.map(({ args }) => this.factory.predict(this.token, ...args)));
+      expect(new Set(allAddresses).size).to.equal(configs.length);
+    });
+
+    it('reverts for incompatible settings', async function () {
+      await expect(this.factory.predict(this.token, true, true)).to.be.revertedWithCustomError(
+        this.factory,
+        'IncompatibleSettings',
+      );
+    });
+
+    for (const { description, args } of configs) {
+      describe(`with ${description}`, function () {
+        it(`returns the address the ${description} is deployed at`, async function () {
+          const predicted = await this.factory.predict(this.token, ...args);
+          await expect(this.factory.deploy.staticCall(this.token, ...args)).to.eventually.equal(predicted);
+        });
+
+        it('does not deploy anything', async function () {
+          const predicted = await this.factory.predict(this.token, ...args);
+          await expect(ethers.provider.getCode(predicted)).to.eventually.equal('0x');
+        });
+
+        it('keeps returning the same address after deployment', async function () {
+          const predicted = await this.factory.predict(this.token, ...args);
+          await this.factory.deploy(this.token, ...args);
+          await expect(this.factory.predict(this.token, ...args)).to.eventually.equal(predicted);
+        });
+
+        it('depends on the underlying token', async function () {
+          await expect(this.factory.predict(this.token, ...args)).to.eventually.not.equal(
+            await this.factory.predict(this.otherToken, ...args),
+          );
+        });
+      });
+    }
+  });
+
+  describe('deploy', function () {
+    it('supports multiple configurations of the same underlying token', async function () {
+      for (const { args } of configs) {
+        await expect(this.factory.deploy(this.token, ...args)).to.emit(this.factory, 'ERC20UniversalWrapperDeployed');
+      }
+    });
+
+    it('reverts for incompatible settings', async function () {
+      await expect(this.factory.deploy(this.token, true, true)).to.be.revertedWithCustomError(
+        this.factory,
+        'IncompatibleSettings',
+      );
+    });
+
+    for (const { description, args } of configs) {
+      const [variableRate, flashMintable] = args;
+      const settings = (variableRate && VARIABLE_RATE_FLAG) || (flashMintable && FLASH_MINT_FLAG) || 0n;
+
+      describe(`with ${description}`, function () {
+        it(`deploys at the predicted address, and emits an event`, async function () {
+          const predicted = await this.factory.predict(this.token, ...args);
+
+          await expect(this.factory.deploy(this.token, ...args))
+            .to.emit(this.factory, 'ERC20UniversalWrapperDeployed')
+            .withArgs(predicted, this.token, settings);
+
+          await expect(ethers.provider.getCode(predicted)).to.eventually.not.equal('0x');
+        });
+
+        it('is permissionless', async function () {
+          const predicted = await this.factory.predict(this.token, ...args);
+
+          await expect(this.factory.connect(this.other).deploy(this.token, ...args))
+            .to.emit(this.factory, 'ERC20UniversalWrapperDeployed')
+            .withArgs(predicted, this.token, settings);
+        });
+
+        it('reverts when the same configuration is deployed twice', async function () {
+          await this.factory.deploy(this.token, ...args);
+
+          await expect(this.factory.deploy(this.token, ...args)).to.be.revertedWithCustomError(
+            this.factory,
+            'FailedDeployment',
+          );
+        });
+      });
+    }
+  });
+
+  describe('deployed wrapper', function () {
+    for (const { description, args } of configs) {
+      const [variableRate, flashMintable] = args;
+
+      describe(description, function () {
+        beforeEach(async function () {
+          await this.factory.deploy(this.token, ...args);
+          this.wrapper = await this.factory
+            .predict(this.token, ...args)
+            .then(address => ethers.getContractAt('ERC20UniversalWrapper', address));
+        });
+
+        it('is configured with the underlying token', async function () {
+          await expect(this.wrapper.asset()).to.eventually.equal(this.token);
+        });
+
+        it('derives its metadata from the underlying token', async function () {
+          await expect(this.wrapper.name()).to.eventually.equal(`Wrapped ${tokenName}`);
+          await expect(this.wrapper.symbol()).to.eventually.equal(`w${tokenSymbol}`);
+          await expect(this.wrapper.decimals()).to.eventually.equal(await this.token.decimals());
+        });
+
+        it(`${flashMintable ? 'enables' : 'disables'} flash minting`, async function () {
+          const currentSupply = await this.wrapper.totalSupply();
+
+          await expect(this.wrapper.maxFlashLoan(this.wrapper)).to.eventually.equal(
+            flashMintable ? ethers.MaxUint256 - currentSupply : 0n,
+          );
+          // never a flash lender for any other token
+          await expect(this.wrapper.maxFlashLoan(this.token)).to.eventually.equal(0n);
+        });
+
+        describe('exchange rate', function () {
+          beforeEach(async function () {
+            // deposit
+            const deposited = 17n;
+            await this.token.$_mint(this.holder, deposited);
+            await this.token.connect(this.holder).approve(this.wrapper, deposited);
+            await this.wrapper.connect(this.holder).deposit(deposited, this.holder);
+            // donation
+            const donated = 42n;
+            await this.token.$_mint(this.wrapper, donated);
+          });
+
+          it(`is ${variableRate ? 'variable' : 'fixed to 1:1'}`, async function () {
+            const amount = ethers.WeiPerEther;
+            if (variableRate) {
+              await expect(this.wrapper.convertToAssets(amount)).to.eventually.be.greaterThan(amount);
+              await expect(this.wrapper.convertToShares(amount)).to.eventually.be.lessThan(amount);
+            } else {
+              await expect(this.wrapper.convertToAssets(amount)).to.eventually.equal(amount);
+              await expect(this.wrapper.convertToShares(amount)).to.eventually.equal(amount);
+            }
+          });
+        });
+
+        it('EIP-712 domain is correct', async function () {
+          const expectedDomain = await ethers.provider.getNetwork().then(({ chainId }) => ({
+            name: `Wrapped ${tokenName}`,
+            version: '1',
+            chainId,
+            verifyingContract: this.wrapper.target,
+          }));
+
+          await expect(getDomain(this.wrapper)).to.eventually.deep.equal(expectedDomain);
+          await expect(this.wrapper.DOMAIN_SEPARATOR()).to.eventually.equal(domainSeparator(expectedDomain));
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
Following [this twitter discussion](https://x.com/Walodja1987/status/2086429936055669119), I wanted to build it using OZ contracts.

Adds `ERC20UniversalWrapper` and `ERC20UniversalWrapperFactory` under `contracts/token/ERC20/examples/`.

## What it does

`ERC20UniversalWrapper` wraps any ERC-20 token, exposing ERC-20 permit, ERC-1363, ERC-3009 and ERC-4626 on top of it.

It is deployed as a **clone with immutable args**: the underlying asset and the feature switches live in the clone's bytecode rather than in storage. The consequences are that it needs no constructor and no initializer, deploying a wrapper costs no storage writes, and each `(asset, settings)` pair maps to a single deterministic address. `name`, `symbol` and `decimals` are derived from the underlying token's metadata, so they aren't stored either (`decimals` degrades to 18 when the asset doesn't expose it).

Two behaviors are configurable per clone, through a settings byte:

| Flag | Effect |
| --- | --- |
| `_VARIABLE_RATE_FLAG` | The wrapper acts as a regular ERC-4626 vault. When unset, the rate is fixed 1:1, as `ERC20Wrapper` would. |
| `_FLASH_MINT_FLAG` | The wrapper token can be flash-minted. When unset, `maxFlashLoan` returns 0. |

The two are mutually exclusive: flash minting shares would interfere with the vault's exchange rate, so requesting both reverts with `IncompatibleSettings`.

`ERC20UniversalWrapperFactory` deploys the shared implementation in its constructor and mints the clones. Deployment is permissionless and idempotent — anyone can deploy the wrapper for a given configuration, but only once — and `predict` computes a wrapper's address ahead of (or without) deployment.

## Tests

42 tests in `test/token/ERC20/examples/ERC20UniversalWrapperFactory.test.js`, table-driven over the three valid settings combinations, covering the implementation, `predict`, `deploy` (address, event, permissionlessness, redeploy revert, coexisting configurations), and the resulting wrapper's asset, metadata, flash-mint switch and exchange rate.

## Notes for reviewers

- `_parseArgs` requires the immutable args to be **exactly** 21 bytes. `Clones.fetchCloneArgs` sizes its result from `code.length - 0x2d`, so a `>=` check would silently pass on the implementation contract itself and decode its own bytecode as an asset address. The strict check makes `MissingImmutableArgs` reachable and the implementation inert; it also means a hand-rolled clone with padded args is rejected rather than tolerated.
- Three imports carry `// prettier-ignore` to keep them on one line; they exceed the configured `printWidth` of 120.

## Follow-ups, deliberately not in this PR

- [ ] `CHANGELOG.md` entry.
- [ ] Listing in `contracts/token/README.adoc` (both the bullet list and the `{{...}}` docs section).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added universal ERC-20 wrappers that can represent underlying tokens with fixed or variable conversion rates.
  * Added optional flash minting and support for permit, flash loan, ERC-1363, ERC-3009, and ERC-4626 integrations.
  * Added a factory for deploying wrappers and predicting their deterministic addresses.
  * Added dynamic token metadata and deployment events.
* **Bug Fixes**
  * Invalid configurations and malformed setup data now fail safely.
  * Flash minting is unavailable unless explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->