### PR TITLE
Document that the ERC7540 share custody hooks must stay constant while a request is outstanding

### DIFF
--- a/contracts/token/ERC20/extensions/ERC7540.sol
+++ b/contracts/token/ERC20/extensions/ERC7540.sol
@@ -816,6 +816,13 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
      * shares (otherwise pre-minted shares could be moved before they are claimed). Use an unowned
      * address such as `address(0xdead)`. Avoid addresses in the precompile reserved range
      * (`address(1)` through `address(0x1ff)`, see EIP-7587).
+     *
+     * IMPORTANT: The returned value MUST stay constant while any request is outstanding, whether Pending or
+     * Claimable. Fulfillment and claim read this hook independently, at different times, and each selects its
+     * branch from its own read. A value that changes in between leaves them inconsistent: shares pre-minted at
+     * fulfillment are stranded and minted a second time on claim, and {totalPendingDepositAssets} is decremented
+     * twice for a single request, the second time against another controller's pending assets, which makes that
+     * controller's claim revert permanently. Prefer an immutable or constant override.
      */
     function _depositShareOrigin() internal view virtual returns (address) {
         return address(0);
@@ -833,6 +840,15 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
      * shares (otherwise escrowed shares could be moved before they are burned). Use an unowned
      * address such as `address(0xdead)`. Avoid addresses in the precompile reserved range
      * (`address(1)` through `address(0x1ff)`, see EIP-7587).
+     *
+     * IMPORTANT: The returned value MUST stay constant from a request until that request is fulfilled. This
+     * hook is read at request time and again at fulfillment, and exactly one of those two reads is meant to
+     * raise {totalPendingRedeemShares}: the request raises it when the hook reads zero, and
+     * {_burnSharesOnRedeemFulfill} raises it when it does not. The claim path never reads this hook, it lowers
+     * that counter unconditionally, so the two earlier reads have to agree. When they do not, either
+     * fulfillment reverts trying to burn from an escrow that never received the shares, or the request is
+     * never counted at all and the claim takes the shortfall out of another controller's accounting, leaving
+     * that controller permanently unable to claim. Prefer an immutable or constant override.
      */
     function _redeemShareDestination() internal view virtual returns (address) {
         return address(0);

--- a/contracts/token/ERC20/extensions/ERC7540DelayDeposit.sol
+++ b/contracts/token/ERC20/extensions/ERC7540DelayDeposit.sol
@@ -30,9 +30,12 @@ import {ERC7540} from "./ERC7540.sol";
  * Override {depositDelay} to customize the waiting period (default: 1 hour) and {clock} to
  * change the time source (default: `block.timestamp`).
  *
- * NOTE: This module does not support temporary share custody through {_depositShareOrigin}. The constructor
- * tries to enforce that property, but the check may be insufficient if {_depositShareOrigin} reads from
- * storage that is not yet initialized when the parent's constructor runs
+ * NOTE: This module does not support temporary share custody through {_depositShareOrigin}, which must return
+ * `address(0)` for the lifetime of the vault, not merely at construction. The constructor tries to enforce that
+ * property, but the check runs once and cannot see an override backed by storage written later, whether by the
+ * child constructor body or by a setter. Such a vault deploys successfully and then sends every claim down the
+ * pre-mint branch, which a delay-based vault never mints into: the claim reverts, the assets stay locked, and
+ * {ERC7540-totalPendingDepositAssets} stays permanently inflated.
  */
 abstract contract ERC7540DelayDeposit is ERC7540, IERC6372 {
     using SafeCast for uint256;

--- a/contracts/token/ERC20/extensions/ERC7540DelayRedeem.sol
+++ b/contracts/token/ERC20/extensions/ERC7540DelayRedeem.sol
@@ -30,9 +30,12 @@ import {ERC7540} from "./ERC7540.sol";
  * Override {redeemDelay} to customize the waiting period (default: 1 hour) and {clock} to
  * change the time source (default: `block.timestamp`).
  *
- * NOTE: This module does not support temporary share custody through {_redeemShareDestination}. The constructor
- * tries to enforce that property, but the check may be insufficient if {_redeemShareDestination} reads from
- * storage that is not yet initialized when the parent's constructor runs.
+ * NOTE: This module does not support temporary share custody through {_redeemShareDestination}, which must
+ * return `address(0)` for the lifetime of the vault, not merely at construction. The constructor tries to
+ * enforce that property, but the check runs once and cannot see an override backed by storage written later,
+ * whether by the child constructor body or by a setter. Such a vault deploys successfully and then escrows
+ * shares on request without recording them in {ERC7540-totalPendingRedeemShares}, so every claim reverts and
+ * the shares are stuck at the escrow.
  */
 abstract contract ERC7540DelayRedeem is ERC7540, IERC6372 {
     using SafeCast for uint256;

--- a/test/token/ERC20/extensions/ERC7540ShareCustody.t.sol
+++ b/test/token/ERC20/extensions/ERC7540ShareCustody.t.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.27;
+
+import {Test, stdError} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {ERC7540MutableCustodyMock, ERC7540StorageCustodyDelayMock} from "./ERC7540ShareCustodyMock.t.sol";
+
+/// @dev The two share custody hooks are read at different stages. {ERC7540-_depositShareOrigin} is read at
+/// fulfillment and again at claim. {ERC7540-_redeemShareDestination} is read at request and again at
+/// fulfillment, never at claim, but the claim lowers {ERC7540-totalPendingRedeemShares} unconditionally and so
+/// depends on those two reads having agreed. Either way the pair has to agree, and these tests show what a
+/// vault whose custody value moves in between does to its own accounting.
+contract ERC7540ShareCustodyTest is Test {
+    ERC20Mock private _asset;
+
+    address private _escrow = makeAddr("escrow");
+    address private _alice = makeAddr("alice");
+    address private _bob = makeAddr("bob");
+
+    uint256 private constant AMOUNT = 1000;
+
+    function setUp() public {
+        _asset = new ERC20Mock();
+    }
+
+    function _fund(address vault, address account) private {
+        _asset.mint(account, AMOUNT);
+        vm.prank(account);
+        _asset.approve(vault, type(uint256).max);
+    }
+
+    /// @dev Custody is dropped between fulfillment and claim. The claim takes the mint-on-claim branch even
+    /// though fulfillment already took the pre-mint branch, so the shares are minted twice and the pending
+    /// asset counter is decremented twice, the second time against another controller's request.
+    function test_dropCustodyBetweenFulfillAndClaim() public {
+        ERC7540MutableCustodyMock vault = new ERC7540MutableCustodyMock(IERC20(address(_asset)), _escrow, _escrow);
+        _fund(address(vault), _alice);
+        _fund(address(vault), _bob);
+
+        vm.prank(_alice);
+        vault.requestDeposit(AMOUNT, _alice, _alice);
+        vm.prank(_bob);
+        vault.requestDeposit(AMOUNT, _bob, _bob);
+        assertEq(vault.totalPendingDepositAssets(), 2 * AMOUNT);
+
+        // Alice is fulfilled under the pre-mint custody model.
+        vault.fulfillDeposit(AMOUNT, AMOUNT, _alice);
+        assertEq(vault.totalPendingDepositAssets(), AMOUNT, "fulfillment consumed Alice's pending assets");
+        assertEq(vault.balanceOf(_escrow), AMOUNT, "shares pre-minted to the escrow");
+
+        vault.setDepositShareOrigin(address(0));
+
+        uint256 supplyBefore = vault.totalSupply();
+        uint256 claimable = vault.maxDeposit(_alice);
+        vm.prank(_alice);
+        vault.deposit(claimable, _alice, _alice);
+
+        // The shares Alice claims are minted a second time; the pre-minted ones stay at the escrow.
+        assertEq(vault.balanceOf(_alice), AMOUNT, "Alice received freshly minted shares");
+        assertEq(vault.balanceOf(_escrow), AMOUNT, "pre-minted shares stranded at the escrow");
+        assertEq(vault.totalSupply(), supplyBefore + AMOUNT, "supply doubled for a single deposit");
+
+        // The second decrement came out of Bob's request, which is still on the books.
+        assertEq(vault.totalPendingDepositAssets(), 0, "Bob's pending assets were consumed by Alice's claim");
+        assertEq(vault.pendingDepositRequest(0, _bob), AMOUNT, "Bob's request still recorded");
+
+        // Bob can no longer be paid: his claim underflows the global counter.
+        vault.fulfillDeposit(AMOUNT, AMOUNT, _bob);
+        uint256 bobClaimable = vault.maxDeposit(_bob);
+        vm.prank(_bob);
+        vm.expectRevert(stdError.arithmeticError);
+        vault.deposit(bobClaimable, _bob, _bob);
+    }
+
+    /// @dev The mirror case. Custody is adopted between fulfillment and claim, so the claim tries to transfer
+    /// shares out of an escrow that fulfillment never pre-minted to.
+    function test_adoptCustodyBetweenFulfillAndClaim() public {
+        ERC7540MutableCustodyMock vault = new ERC7540MutableCustodyMock(
+            IERC20(address(_asset)),
+            address(0),
+            address(0)
+        );
+        _fund(address(vault), _alice);
+
+        vm.prank(_alice);
+        vault.requestDeposit(AMOUNT, _alice, _alice);
+        vault.fulfillDeposit(AMOUNT, AMOUNT, _alice);
+        assertEq(vault.balanceOf(_escrow), 0, "mint-on-claim fulfillment pre-mints nothing");
+        assertEq(vault.totalPendingDepositAssets(), AMOUNT);
+
+        vault.setDepositShareOrigin(_escrow);
+
+        uint256 claimable = vault.maxDeposit(_alice);
+        vm.prank(_alice);
+        vm.expectRevert(); // transfer from an escrow that holds no shares
+        vault.deposit(claimable, _alice, _alice);
+    }
+
+    /// @dev Redeem side. The hook is read at request and again at fulfillment, and the two reads have to
+    /// agree: exactly one of them raises `_totalPendingRedeemShares`. The claim never reads the hook, it
+    /// lowers that counter unconditionally, so a request whose two reads disagree is never counted and the
+    /// claim takes the shortfall out of whatever another controller put there.
+    function test_dropRedeemCustodyBetweenRequestAndFulfill() public {
+        ERC7540MutableCustodyMock vault = new ERC7540MutableCustodyMock(IERC20(address(_asset)), address(0), _escrow);
+        _fund(address(vault), _alice);
+        _fund(address(vault), _bob);
+
+        // Both hold shares, minted one for one.
+        address[2] memory holders = [_alice, _bob];
+        for (uint256 i = 0; i < holders.length; ++i) {
+            vm.prank(holders[i]);
+            vault.requestDeposit(AMOUNT, holders[i], holders[i]);
+            vault.fulfillDeposit(AMOUNT, AMOUNT, holders[i]);
+            uint256 claimable = vault.maxDeposit(holders[i]);
+            vm.prank(holders[i]);
+            vault.deposit(claimable, holders[i], holders[i]);
+            assertEq(vault.balanceOf(holders[i]), AMOUNT);
+        }
+
+        // Alice requests under the escrow model: shares move, the counter is not raised.
+        vm.prank(_alice);
+        vault.requestRedeem(AMOUNT, _alice, _alice);
+        assertEq(vault.balanceOf(_escrow), AMOUNT, "Alice's shares escrowed");
+        assertEq(vault.totalPendingRedeemShares(), 0, "escrow branch raises nothing at request");
+
+        vault.setRedeemShareDestination(address(0));
+
+        // Bob requests under the burn-at-request model: his shares are burned and counted.
+        vm.prank(_bob);
+        vault.requestRedeem(AMOUNT, _bob, _bob);
+        assertEq(vault.totalPendingRedeemShares(), AMOUNT, "only Bob's request is counted");
+
+        // Neither fulfillment raises the counter now, because the hook reads zero for both.
+        vault.fulfillRedeem(AMOUNT, AMOUNT, _alice);
+        vault.fulfillRedeem(AMOUNT, AMOUNT, _bob);
+        assertEq(vault.totalPendingRedeemShares(), AMOUNT, "Alice's request was never counted");
+        assertEq(vault.balanceOf(_escrow), AMOUNT, "Alice's escrowed shares were never burned");
+
+        // Alice claims and is paid, out of the counter Bob's request populated.
+        uint256 aliceBefore = _asset.balanceOf(_alice);
+        vm.prank(_alice);
+        vault.redeem(AMOUNT, _alice, _alice);
+        assertEq(_asset.balanceOf(_alice) - aliceBefore, AMOUNT, "Alice was paid");
+        assertEq(vault.totalPendingRedeemShares(), 0, "Alice consumed Bob's accounting");
+
+        // Bob cannot claim any more.
+        vm.prank(_bob);
+        vm.expectRevert(stdError.arithmeticError);
+        vault.redeem(AMOUNT, _bob, _bob);
+
+        // And the escrowed shares are still outstanding, so supply stays overstated.
+        assertEq(vault.balanceOf(_escrow), AMOUNT, "escrowed shares never burned");
+    }
+
+    /// @dev The ERC7540Delay modules check the custody hooks once, in their constructor. A storage-backed
+    /// override written by the child constructor body passes that check and then takes the very branch the
+    /// module documents as unsupported, which strands the shares and bricks every redeem claim.
+    function test_delayConstructorCheckMissesStorageBackedOverride() public {
+        ERC7540StorageCustodyDelayMock vault = new ERC7540StorageCustodyDelayMock(
+            IERC20(address(_asset)),
+            address(0),
+            _escrow
+        );
+        assertEq(vault.redeemShareDestination(), _escrow, "constructor check passed on an unsupported vault");
+
+        _fund(address(vault), _alice);
+        vm.prank(_alice);
+        vault.requestDeposit(AMOUNT, _alice, _alice);
+        vm.warp(block.timestamp + 2 hours);
+        uint256 claimable = vault.maxDeposit(_alice);
+        vm.prank(_alice);
+        vault.deposit(claimable, _alice, _alice);
+
+        uint256 shares = vault.balanceOf(_alice);
+        assertGt(shares, 0);
+
+        vm.prank(_alice);
+        vault.requestRedeem(shares, _alice, _alice);
+
+        // The escrow branch ran: shares were moved instead of burned, so the pending counter was never raised.
+        assertEq(vault.balanceOf(_escrow), shares, "shares escrowed rather than burned");
+        assertEq(vault.totalPendingRedeemShares(), 0, "pending redeem shares never recorded");
+
+        vm.warp(block.timestamp + 2 hours);
+        uint256 redeemable = vault.maxRedeem(_alice);
+        assertEq(redeemable, shares, "the request is still claimable on paper");
+
+        vm.prank(_alice);
+        vm.expectRevert(stdError.arithmeticError);
+        vault.redeem(redeemable, _alice, _alice);
+
+        assertEq(vault.balanceOf(_alice), 0, "Alice cannot recover her shares");
+        assertEq(vault.balanceOf(_escrow), shares, "the shares remain stuck at the escrow");
+    }
+
+    /// @dev Deposit-side mirror of the previous test. The escaped check leaves the claim reaching for
+    /// pre-minted shares that a delay-based vault never mints, so the assets stay locked and
+    /// {totalPendingDepositAssets} stays permanently inflated.
+    function test_delayConstructorCheckMissesStorageBackedOriginOverride() public {
+        ERC7540StorageCustodyDelayMock vault = new ERC7540StorageCustodyDelayMock(
+            IERC20(address(_asset)),
+            _escrow,
+            address(0)
+        );
+        assertEq(vault.depositShareOrigin(), _escrow, "constructor check passed on an unsupported vault");
+
+        _fund(address(vault), _alice);
+        vm.prank(_alice);
+        vault.requestDeposit(AMOUNT, _alice, _alice);
+        assertEq(vault.totalPendingDepositAssets(), AMOUNT);
+
+        vm.warp(block.timestamp + 2 hours);
+        uint256 claimable = vault.maxDeposit(_alice);
+        assertEq(claimable, AMOUNT, "the request is claimable on paper");
+
+        vm.prank(_alice);
+        vm.expectRevert(); // transfer from an escrow a delay vault never pre-mints to
+        vault.deposit(claimable, _alice, _alice);
+
+        assertEq(vault.totalPendingDepositAssets(), AMOUNT, "pending assets stay inflated forever");
+        assertEq(vault.totalAssets(), 0, "the deposited assets are permanently excluded from totalAssets");
+        assertEq(_asset.balanceOf(address(vault)), AMOUNT, "the assets are stuck in the vault");
+    }
+}

--- a/test/token/ERC20/extensions/ERC7540ShareCustodyMock.t.sol
+++ b/test/token/ERC20/extensions/ERC7540ShareCustodyMock.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.27;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC7540} from "@openzeppelin/community-contracts/token/ERC20/extensions/ERC7540.sol";
+import {ERC7540AdminDeposit} from "@openzeppelin/community-contracts/token/ERC20/extensions/ERC7540AdminDeposit.sol";
+import {ERC7540AdminRedeem} from "@openzeppelin/community-contracts/token/ERC20/extensions/ERC7540AdminRedeem.sol";
+import {ERC7540DelayDeposit} from "@openzeppelin/community-contracts/token/ERC20/extensions/ERC7540DelayDeposit.sol";
+import {ERC7540DelayRedeem} from "@openzeppelin/community-contracts/token/ERC20/extensions/ERC7540DelayRedeem.sol";
+
+/// @dev Admin-fulfilled vault whose share custody addresses are stored, and therefore mutable.
+contract ERC7540MutableCustodyMock is ERC7540AdminDeposit, ERC7540AdminRedeem {
+    address private _origin;
+    address private _destination;
+
+    constructor(IERC20 asset_, address origin_, address destination_) ERC20("Mutable", "MUT") ERC7540(asset_) {
+        _origin = origin_;
+        _destination = destination_;
+    }
+
+    function setDepositShareOrigin(address origin_) public {
+        _origin = origin_;
+    }
+
+    function setRedeemShareDestination(address destination_) public {
+        _destination = destination_;
+    }
+
+    function fulfillDeposit(uint256 assets, uint256 shares, address controller) public {
+        _fulfillDeposit(assets, shares, controller);
+    }
+
+    function fulfillRedeem(uint256 shares, uint256 assets, address controller) public {
+        _fulfillRedeem(shares, assets, controller);
+    }
+
+    function _depositShareOrigin() internal view virtual override returns (address) {
+        return _origin;
+    }
+
+    function _redeemShareDestination() internal view virtual override returns (address) {
+        return _destination;
+    }
+
+    function _requestDeposit(
+        uint256 assets,
+        address controller,
+        address owner,
+        uint256 requestId
+    ) internal virtual override(ERC7540, ERC7540AdminDeposit) returns (uint256) {
+        return super._requestDeposit(assets, controller, owner, requestId);
+    }
+
+    function _requestRedeem(
+        uint256 shares,
+        address controller,
+        address owner,
+        uint256 requestId
+    ) internal virtual override(ERC7540, ERC7540AdminRedeem) returns (uint256) {
+        return super._requestRedeem(shares, controller, owner, requestId);
+    }
+}
+
+/// @dev Delay vault whose share custody addresses are written by the constructor body, i.e. after the
+/// ERC7540DelayDeposit and ERC7540DelayRedeem constructors have already read them. This is the shape the
+/// modules' own NOTE describes as possibly escaping the constructor check.
+contract ERC7540StorageCustodyDelayMock is ERC7540DelayDeposit, ERC7540DelayRedeem {
+    address private _origin;
+    address private _destination;
+
+    constructor(IERC20 asset_, address origin_, address destination_) ERC20("Delay", "DLY") ERC7540(asset_) {
+        _origin = origin_;
+        _destination = destination_;
+    }
+
+    function depositShareOrigin() public view returns (address) {
+        return _depositShareOrigin();
+    }
+
+    function redeemShareDestination() public view returns (address) {
+        return _redeemShareDestination();
+    }
+
+    function clock() public view virtual override(ERC7540DelayDeposit, ERC7540DelayRedeem) returns (uint48) {
+        return super.clock();
+    }
+
+    function CLOCK_MODE()
+        public
+        view
+        virtual
+        override(ERC7540DelayDeposit, ERC7540DelayRedeem)
+        returns (string memory)
+    {
+        return super.CLOCK_MODE();
+    }
+
+    function _depositShareOrigin() internal view virtual override returns (address) {
+        return _origin;
+    }
+
+    function _redeemShareDestination() internal view virtual override returns (address) {
+        return _destination;
+    }
+
+    function _requestDeposit(
+        uint256 assets,
+        address controller,
+        address owner,
+        uint256 requestId
+    ) internal virtual override(ERC7540, ERC7540DelayDeposit) returns (uint256) {
+        return super._requestDeposit(assets, controller, owner, requestId);
+    }
+
+    function _requestRedeem(
+        uint256 shares,
+        address controller,
+        address owner,
+        uint256 requestId
+    ) internal virtual override(ERC7540, ERC7540DelayRedeem) returns (uint256) {
+        return super._requestRedeem(shares, controller, owner, requestId);
+    }
+}


### PR DESCRIPTION
## What this changes

Documentation only, plus tests. It states a requirement on `ERC7540._depositShareOrigin()` and
`ERC7540._redeemShareDestination()` that the code already depends on but that nothing wrote down: the value
each returns has to stay constant while a request is outstanding, whether Pending or Claimable.

The existing note on both hooks says the address "must not be able to transfer shares". That is necessary
but not sufficient. An address that satisfies it perfectly still breaks the vault if the hook stops
returning it partway through a request.

## Mechanism

The two share custody models are selected by reading the hook, and the reads happen in separate calls at
separate times. Each call picks its branch from its own read, and nothing carries the earlier decision
forward.

Deposit side:

* `_fulfillDeposit` reads the hook and, when it is non-zero, calls `_mintSharesOnDepositFulfill`, which
  decrements `_totalPendingDepositAssets` and pre-mints the shares to the origin.
* `_deposit` reads the hook again at claim time. When it is zero it decrements
  `_totalPendingDepositAssets` a second time and mints the shares again, instead of transferring the
  pre-minted ones.

Redeem side has the same two read shape but at different stages, and the damage surfaces one stage later:

* `_requestRedeem` reads the hook. Zero means burn the shares and raise `_totalPendingRedeemShares`. Non-zero
  means escrow the shares and raise nothing.
* `_fulfillRedeem` reads it again. Non-zero means call `_burnSharesOnRedeemFulfill`, which raises
  `_totalPendingRedeemShares` and burns from the escrow.
* `_withdraw` never reads this hook. On the async path it lowers `_totalPendingRedeemShares` unconditionally.

So exactly one of the first two reads is meant to raise the counter that the third one lowers. A value that
changes between them leaves the request counted twice or not at all, and the claim is where that surfaces even
though the claim is not what chose the branch.

## Why the constructor check in the Delay modules does not cover this

`ERC7540DelayDeposit` and `ERC7540DelayRedeem` do check their hook, but only once, in their constructor.
Their own note already anticipates that this is not airtight:

> The constructor tries to enforce that property, but the check may be insufficient if
> `_depositShareOrigin` reads from storage that is not yet initialized when the parent's constructor runs

That case is real and needs no privileged action at all. A child that writes the address in its own
constructor body writes it after the parent constructors have already read it, so the guard sees `address(0)`
and passes. The vault then deploys successfully and takes the branch the module documents as unsupported, on
every single request. The note stops at "may be insufficient" and never says what happens next, which is what
this PR fills in.

## Impact, stated plainly

Two different situations, and they are not equally severe.

The `ERC7540Admin*` case needs a privileged integrator to both make the hook mutable and change it with
requests in flight. That is not an unprivileged exploit, and whoever can change it is already trusted. What
makes it worth writing down is that the damage is silent and lands on someone else: in
`test_dropCustodyBetweenFulfillAndClaim`, Alice's claim mints her shares a second time, strands the
pre-minted ones at the old escrow, doubles `totalSupply` for a single 1000 asset deposit, and takes its
second `_totalPendingDepositAssets` decrement out of Bob's pending request. Bob's own claim then reverts
with an arithmetic underflow and cannot be recovered.

The redeem side has the same shape over a shorter interval. In
`test_dropRedeemCustodyBetweenRequestAndFulfill`, Alice requests while custody is an escrow, custody is then
set to zero, and Bob requests under the burn model. Neither fulfillment raises the counter, so Alice's request
was never counted and her claim is paid out of what Bob's request put there. Bob's own claim then reverts with
an arithmetic underflow, and Alice's escrowed shares are never burned, so supply stays overstated.

The `ERC7540Delay*` case needs no flip and no privileged call. A storage backed override alone is enough,
and the vault is broken from deployment: every redeem claim reverts with an arithmetic underflow while the
shares sit at the escrow, or on the deposit side every claim reverts while `totalPendingDepositAssets` stays
permanently inflated and `totalAssets()` permanently understated.

## Tests

Five tests in `test/token/ERC20/extensions/ERC7540ShareCustody.t.sol`, all against unmodified library code:

| test | shape |
| --- | --- |
| `test_dropCustodyBetweenFulfillAndClaim` | Admin vault, custody dropped between fulfill and claim: double mint, and another controller's claim bricked |
| `test_adoptCustodyBetweenFulfillAndClaim` | Admin vault, custody adopted between fulfill and claim: claim reverts reaching for shares never pre-minted |
| `test_dropRedeemCustodyBetweenRequestAndFulfill` | Admin vault, redeem custody dropped between request and fulfill: one controller's claim paid out of another's accounting, that other one bricked |
| `test_delayConstructorCheckMissesStorageBackedOverride` | Delay vault, storage backed redeem destination: constructor guard passes, every redeem claim reverts, shares stuck |
| `test_delayConstructorCheckMissesStorageBackedOriginOverride` | Delay vault, storage backed deposit origin: constructor guard passes, every deposit claim reverts, assets locked |

Following the layout already used by `ERC20uRWA.t.sol` and `ERC20uRWAMock.t.sol`, the vaults live in
`ERC7540ShareCustodyMock.t.sol`.

The existing suite for this family is unchanged and still passes: `ERC7540Admin`, `ERC7540Delay`,
`ERC7540Sync`, `ERC7540SyncDeposit` and `ERC7540SyncRedeem` give 333 passing, 2 pending.
`npm run lint:sol` is clean.

## Not in this PR

The stronger fix is to make the two sides agree by construction rather than by documentation, for example by
snapshotting the hook once per request and having fulfillment and claim both read the snapshot. That changes
behavior and storage rather than comments, so per CONTRIBUTING it seems like something to agree on first
rather than push unannounced. Happy to open it separately if you want it, or to fold it in here.

A narrower option for the Delay modules specifically is to repeat the constructor check on the request path,
which would catch the storage backed override at the point it first matters. That costs gas on a hot path, so
it is also a call for a maintainer rather than mine.

On the CONTRIBUTING rule that non-trivial code contributions be discussed in an issue first: this changes no
behavior, no storage and no interface, only comments and tests, so opening it directly read as within "very
minor" to me. The two options above are exactly the parts that would change behavior, which is why they are
left out. If you would rather have had this as an issue first, say so and I will move it.

## Duplicate check

No issue or PR in this repository mentions `_depositShareOrigin`, `_redeemShareDestination` or share custody
outside #232, which added the current note and constructor check. This is meant to continue that work rather
than revisit it.
