### PR TITLE
ERC7540: forbid a controller from being its own operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 02-09-2026
+
+- `ERC7540`: `_setOperator` now reverts with `ERC7540InvalidSelfOperator` when the controller is set as its own operator. A controller always has unrestricted access to its own tokens and requests, and that access cannot be restricted.
+
 ## 04-08-2026
 
 - `SignerAccessManaged`: Add an `AbstractSigner` whose authority is delegated to the members of a role tracked by an `IAccessManager`. A signature is accepted only when its `[signer][inner signature]` payload is valid and the signer currently holds the bound role.

--- a/contracts/token/ERC20/extensions/ERC7540.sol
+++ b/contracts/token/ERC20/extensions/ERC7540.sol
@@ -90,6 +90,9 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
     /// @dev The `operator` is not the caller or an approved operator of the `controller`.
     error ERC7540InvalidOperator(address controller, address operator);
 
+    /// @dev The `controller` cannot set (or unset) itself as its own operator.
+    error ERC7540InvalidSelfOperator(address controller);
+
     /// @dev A deposit Request was attempted but {_isDepositAsync} returns `false`.
     error ERC7540SyncDeposit();
 
@@ -171,9 +174,15 @@ abstract contract ERC7540 is ERC165, ERC20, IERC4626, IERC7540, IERC7575Share {
     /**
      * @dev Sets the `operator` approval status for `controller` to `approved`.
      *
+     * Requirements:
+     *
+     * * `operator` must not be the `controller`. A controller always has unrestricted access to its own
+     *   tokens and requests, and that access cannot be revoked.
+     *
      * Emits an {IERC7540Operator-OperatorSet} event.
      */
     function _setOperator(address controller, address operator, bool approved) internal {
+        require(controller != operator, ERC7540InvalidSelfOperator(controller));
         _isOperator[controller][operator] = approved;
         emit OperatorSet(controller, operator, approved);
     }

--- a/test/token/ERC20/extensions/ERC7540.behavior.js
+++ b/test/token/ERC20/extensions/ERC7540.behavior.js
@@ -40,6 +40,12 @@ function shouldBehaveLikeERC7540Operator() {
 
         await expect(this.mock.isOperator(this.owner, this.operator)).to.eventually.equal(status);
       });
+
+      it(`setOperator to ${status} reverts if the operator is the controller`, async function () {
+        await expect(this.mock.connect(this.owner).setOperator(this.owner, status))
+          .to.be.revertedWithCustomError(this.mock, 'ERC7540InvalidSelfOperator')
+          .withArgs(this.owner);
+      });
     }
   });
 }


### PR DESCRIPTION
`_setOperator` now reverts with a new `ERC7540InvalidSelfOperator(address controller)` error when `controller == operator`.

Rationale: a controller always has unlimited access to its own tokens and requests, and that access cannot be restricted. Allowing `setOperator(self, ...)` would write a storage flag that has no effect on authorization — `_checkOperatorOrController` already short-circuits on `controller == operator` — and would emit an `OperatorSet` event that misleadingly suggests the (un)approval is meaningful. In particular, `setOperator(self, false)` looks like it revokes access when it does not.

Changes:
- New `ERC7540InvalidSelfOperator` error.
- `require(controller != operator, ...)` in `_setOperator`, documented under a `Requirements:` section in the natspec.
- Test coverage in `shouldBehaveLikeERC7540Operator` for both `approved = true` and `approved = false`.
- CHANGELOG entry.

No authorization behavior changes: self-access was, and remains, unrestricted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented controllers from assigning themselves as operators; such attempts now fail with a clear validation error.
  - Controllers continue to retain unrestricted access to their own tokens and requests.

- **Documentation**
  - Updated the changelog and operator behavior documentation to reflect the self-assignment restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->