### PR TITLE
Remove wormholeChainId from adapter

### DIFF
--- a/contracts/crosschain/wormhole/WormholeGatewayAdapter.sol
+++ b/contracts/crosschain/wormhole/WormholeGatewayAdapter.sol
@@ -25,7 +25,6 @@ contract WormholeGatewayAdapter is IERC7786GatewaySource, IWormholeReceiver, Own
     using InteroperableAddress for bytes;
 
     IWormholeRelayer internal immutable _wormholeRelayer;
-    uint16 internal immutable _wormholeChainId;
     uint24 private constant EVM_ID_FLAG = 1 << 16;
 
     // Remote gateway.
@@ -76,9 +75,8 @@ contract WormholeGatewayAdapter is IERC7786GatewaySource, IWormholeReceiver, Own
     }
 
     /// @dev Initializes the contract with the Wormhole gateway and the initial owner.
-    constructor(IWormholeRelayer wormholeRelayer, uint16 wormholeChainId, address initialOwner) Ownable(initialOwner) {
+    constructor(IWormholeRelayer wormholeRelayer, address initialOwner) Ownable(initialOwner) {
         _wormholeRelayer = wormholeRelayer;
-        _wormholeChainId = wormholeChainId;
     }
 
     /// @dev Returns the local Wormhole relayer

--- a/test/crosschain/wormhole/WormholeHelper.js
+++ b/test/crosschain/wormhole/WormholeHelper.js
@@ -8,8 +8,8 @@ async function deploy(owner, wormholeChainId = 23600) {
   const chain = await getLocalChain();
 
   const wormhole = await ethers.deployContract('WormholeRelayerMock', [wormholeChainId]);
-  const gatewayA = await ethers.deployContract('WormholeGatewayAdapter', [wormhole, wormholeChainId, owner]);
-  const gatewayB = await ethers.deployContract('WormholeGatewayAdapter', [wormhole, wormholeChainId, owner]);
+  const gatewayA = await ethers.deployContract('WormholeGatewayAdapter', [wormhole, owner]);
+  const gatewayB = await ethers.deployContract('WormholeGatewayAdapter', [wormhole, owner]);
 
   await gatewayA.connect(owner).registerChainEquivalence(ethers.Typed.bytes(chain.erc7930), wormholeChainId);
   await gatewayB.connect(owner).registerChainEquivalence(ethers.Typed.bytes(chain.erc7930), wormholeChainId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Wormhole gateway setup to rely on configured chain mappings rather than a separately supplied chain ID.
  * Simplified gateway deployment configuration by removing the chain ID constructor parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->